### PR TITLE
add variationName and variationKey to Feature model

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ signing {
 
 group = 'com.devcycle'
 archivesBaseName = "java-server-sdk"
-version = '1.0.4'
+version = '1.0.5'
 
 uploadArchives {
     repositories {

--- a/src/main/java/com/devcycle/sdk/server/api/DVCClient.java
+++ b/src/main/java/com/devcycle/sdk/server/api/DVCClient.java
@@ -18,9 +18,9 @@ public final class DVCClient {
   private final DVCApi api;
 
   private static final String DEFAULT_PLATFORM = "Java";
-  private static final String DEFAULT_PLATFORM_VERSION = Runtime.class.getPackage().getImplementationVersion();
+  private static final String DEFAULT_PLATFORM_VERSION = System.getProperty("java.version");
   private static final User.SdkTypeEnum DEFAULT_SDK_TYPE = User.SdkTypeEnum.SERVER;
-  private static final String DEFAULT_SDK_VERSION = "1.0.0";
+  private static final String DEFAULT_SDK_VERSION = "1.0.5";
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 

--- a/src/main/java/com/devcycle/sdk/server/model/Feature.java
+++ b/src/main/java/com/devcycle/sdk/server/model/Feature.java
@@ -12,6 +12,7 @@
 
 package com.devcycle.sdk.server.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -26,6 +27,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Feature {
 
+  @JsonIgnoreProperties(ignoreUnknown = true)
+
   @Schema(required = true, description = "unique database id")
   @JsonProperty("_id")
   private String id;
@@ -39,6 +42,14 @@ public class Feature {
   @Schema(required = true, description = "Bucketed feature variation")
   @JsonProperty("_variation")
   private String variation;
+
+  @Schema(required = true, description = "Bucketed feature variation key")
+  @JsonProperty("variationKey")
+  private String variationKey;
+
+  @Schema(required = true, description = "Bucketed feature variation name")
+  @JsonProperty("variationName")
+  private String variationName;
 
   @Schema(description = "Evaluation reasoning")
   private String evalReason;

--- a/src/main/java/com/devcycle/sdk/server/model/User.java
+++ b/src/main/java/com/devcycle/sdk/server/model/User.java
@@ -12,6 +12,7 @@
 
 package com.devcycle.sdk.server.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -22,6 +23,8 @@ import lombok.NonNull;
 @Data
 @Builder
 public class User {
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
 
   @NonNull
   @Schema(required = true, description = "Unique id to identify the user")
@@ -58,10 +61,10 @@ public class User {
   @Schema(description = "Date the user was last seen, Unix epoch timestamp format")
   private Long lastSeenDate;
 
-  @Schema(description = "Platform the Client SDK is running on")
+  @Schema(description = "Platform the SDK is running on")
   private String platform;
 
-  @Schema(description = "Version of the platform the Client SDK is running on")
+  @Schema(description = "Version of the platform the SDK is running on")
   private String platformVersion;
 
   @Schema(description = "User's device model")

--- a/src/main/java/com/devcycle/sdk/server/model/Variable.java
+++ b/src/main/java/com/devcycle/sdk/server/model/Variable.java
@@ -13,6 +13,7 @@
 
 package com.devcycle.sdk.server.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,6 +28,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Variable<T> {
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
 
   @Schema(required = true, description = "unique database id")
   @JsonProperty("_id")

--- a/src/test/java/com/devcycle/sdk/server/api/DVCClientTest.java
+++ b/src/test/java/com/devcycle/sdk/server/api/DVCClientTest.java
@@ -147,6 +147,7 @@ public class DVCClientTest {
     private void assertUserDefaultsCorrect(User user) {
         Assert.assertEquals("Java", user.getPlatform());
         Assert.assertEquals(User.SdkTypeEnum.SERVER, user.getSdkType());
-        Assert.assertEquals("1.0.0", user.getSdkVersion());
+        Assert.assertNotNull(user.getPlatformVersion());
+        Assert.assertEquals("1.0.5", user.getSdkVersion());
     }
 }


### PR DESCRIPTION
- allows for easy identification of which variation of a given feature is being served to the user
- add `@JsonIgnoreProperties(ignoreUnknown = true)` to Feature, User and Variable models
- version bump to 1.0.5