### PR TITLE
fix to ignore new properties added at the root level of a project config

### DIFF
--- a/src/main/java/com/devcycle/sdk/server/common/model/ErrorResponse.java
+++ b/src/main/java/com/devcycle/sdk/server/common/model/ErrorResponse.java
@@ -12,6 +12,7 @@
 
 package com.devcycle.sdk.server.common.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,8 +23,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ErrorResponse {
-
   @Schema(required = true, description = "HTTP Status Code")
   private int statusCode;
 

--- a/src/main/java/com/devcycle/sdk/server/common/model/Feature.java
+++ b/src/main/java/com/devcycle/sdk/server/common/model/Feature.java
@@ -25,10 +25,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Feature {
-
-  @JsonIgnoreProperties(ignoreUnknown = true)
-
   @Schema(required = true, description = "unique database id")
   @JsonProperty("_id")
   private String id;

--- a/src/main/java/com/devcycle/sdk/server/common/model/ProjectConfig.java
+++ b/src/main/java/com/devcycle/sdk/server/common/model/ProjectConfig.java
@@ -11,10 +11,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ProjectConfig {
-
-  @JsonIgnoreProperties(ignoreUnknown = false)
-
   @Schema(description = "Project Settings")
   private Object project;
 

--- a/src/main/java/com/devcycle/sdk/server/common/model/User.java
+++ b/src/main/java/com/devcycle/sdk/server/common/model/User.java
@@ -28,9 +28,6 @@ import lombok.extern.jackson.Jacksonized;
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class User {
-
-  @JsonIgnoreProperties(ignoreUnknown = true)
-
   @NonNull
   @Schema(required = true, description = "Unique id to identify the user")
   @JsonProperty("user_id")

--- a/src/main/java/com/devcycle/sdk/server/common/model/Variable.java
+++ b/src/main/java/com/devcycle/sdk/server/common/model/Variable.java
@@ -27,10 +27,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Variable<T> {
-
-  @JsonIgnoreProperties(ignoreUnknown = true)
-
   @Schema(required = true, description = "unique database id")
   @JsonProperty("_id")
   private String id;

--- a/src/main/java/com/devcycle/sdk/server/local/model/Project.java
+++ b/src/main/java/com/devcycle/sdk/server/local/model/Project.java
@@ -22,7 +22,7 @@ public class Project {
                 public String secondary;
             }
             public Colors colors;
-
+            public String poweredByAlignment;
         }
 
         public EdgeDBSettings edgeDB;


### PR DESCRIPTION
- allow for JSON parsing of a Project Config with unknown root level properties
- add support for local bucketing to generate proper payloads to handle `project.settings.optIn.poweredByAlignment` attribute