### PR TITLE
Release 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can use the SDK in your Maven project by adding the following to your *pom.x
 <dependency>
     <groupId>com.devcycle</groupId>
     <artifactId>java-server-sdk</artifactId>
-    <version>1.1.3</version>
+    <version>1.2.0</version>
     <scope>compile</scope>
 </dependency>
 ```
@@ -27,7 +27,7 @@ You can use the SDK in your Maven project by adding the following to your *pom.x
 Alternatively you can use the SDK in your Gradle project by adding the following to *build.gradle*:
 
 ```yaml
-implementation("com.devcycle:java-server-sdk:1.1.3")
+implementation("com.devcycle:java-server-sdk:1.2.0")
 ```
 
 ## DNS Caching

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ signing {
 
 group = "com.devcycle"
 archivesBaseName = "java-server-sdk"
-version = "1.1.3"
+version = "1.2.0"
 
 uploadArchives {
     repositories {
@@ -103,7 +103,7 @@ task execute(type:JavaExec) {
 }
 
 def wasmResourcePath = "$projectDir/src/main/resources"
-def wasmVersion = "1.1.28"
+def wasmVersion = "1.3.3"
 def wasmUrl = "https://unpkg.com/@devcycle/bucketing-assembly-script@$wasmVersion/build/bucketing-lib.release.wasm"
 task downloadDVCBucketingWASM(type: Download) {
     src wasmUrl

--- a/src/main/java/com/devcycle/sdk/server/common/model/PlatformData.java
+++ b/src/main/java/com/devcycle/sdk/server/common/model/PlatformData.java
@@ -44,7 +44,7 @@ public class PlatformData {
 
     @Schema(description = "DevCycle SDK Version")
     @Builder.Default
-    private String sdkVersion = "1.1.3";
+    private String sdkVersion = "1.2.0";
 
     @Schema(description = "Hostname where the SDK is running")
     private String hostname;

--- a/src/test/java/com/devcycle/sdk/server/cloud/DVCCloudClientTest.java
+++ b/src/test/java/com/devcycle/sdk/server/cloud/DVCCloudClientTest.java
@@ -156,6 +156,6 @@ public class DVCCloudClientTest {
         Assert.assertEquals("Java", user.getPlatform());
         Assert.assertEquals(PlatformData.SdkTypeEnum.SERVER, user.getSdkType());
         Assert.assertNotNull(user.getPlatformVersion());
-        Assert.assertEquals("1.1.3", user.getSdkVersion());
+        Assert.assertEquals("1.2.0", user.getSdkVersion());
     }
 }


### PR DESCRIPTION
- Update WASM to `1.3.3`
- Renamed all instances of `envKey` / `env_key` /  `environmentKey` / etc, to `sdkKey` to be consistent with all DevCycle SDKs. #47