### PR TITLE
DVC-6296 ignore unknown properties dvc response

### DIFF
--- a/src/main/java/com/devcycle/sdk/server/common/model/DVCResponse.java
+++ b/src/main/java/com/devcycle/sdk/server/common/model/DVCResponse.java
@@ -12,6 +12,8 @@
 
 package com.devcycle.sdk.server.common.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -21,7 +23,9 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DVCResponse {
 
+  @Schema(required = false, description = "Response message")
   private String message;
 }


### PR DESCRIPTION
- test harness was failing in `getResponse` on the `EventQueueManager` because the test harness tests weren't passing in a body
- pass in a body, and ignore unknown properties