### PR TITLE
Fixed bug with customData not set properly in Protobuf message

### DIFF
--- a/src/main/java/com/devcycle/sdk/server/local/utils/ProtobufUtils.java
+++ b/src/main/java/com/devcycle/sdk/server/local/utils/ProtobufUtils.java
@@ -28,7 +28,7 @@ public class ProtobufUtils {
                 .setAppBuild(createNullableDouble(appBuild))
                 .setAppVersion(createNullableString(user.getAppVersion()))
                 .setCustomData(createNullableCustomData(user.getCustomData()))
-                .setCustomData(createNullableCustomData(user.getPrivateCustomData()))
+                .setPrivateCustomData(createNullableCustomData(user.getPrivateCustomData()))
                 .build();
     }
 

--- a/src/test/java/com/devcycle/sdk/server/helpers/TestDataFixtures.java
+++ b/src/test/java/com/devcycle/sdk/server/helpers/TestDataFixtures.java
@@ -40,4 +40,8 @@ public class TestDataFixtures {
     public static String SmallConfigWithSpecialCharacters() {
         return loadConfigData("fixture_small_config_special_characters.json");
     }
+
+    public static String SmallConfigWithCustomDataBucketing() {
+        return loadConfigData("fixture_small_config_custom_data_bucketing.json");
+    }
 }

--- a/src/test/java/com/devcycle/sdk/server/local/DVCLocalClientTest.java
+++ b/src/test/java/com/devcycle/sdk/server/local/DVCLocalClientTest.java
@@ -152,7 +152,22 @@ public class DVCLocalClientTest {
         Assert.assertFalse(var.getIsDefaulted());
         Assert.assertEquals("variationOn", var.getValue());
     }
+    @Test
+    public void variableTestBucketingWithCustomData(){
+        // Make sure we are properly sending custom data to the WASM so the user is bucketed correctly
 
+        DVCLocalClient myClient = createClient(TestDataFixtures.SmallConfigWithCustomDataBucketing());
+        User user = getUser();
+
+        Map<String,Object> customData = new HashMap();
+        customData.put("should-bucket", true);
+        user.setCustomData(customData);
+
+        Variable<String> var = myClient.variable(user, "unicode-var", "default string");
+        Assert.assertNotNull(var);
+        Assert.assertFalse(var.getIsDefaulted());
+        Assert.assertEquals("↑↑↓↓←→←→BA 🤖", var.getValue());
+    }
     @Test
     public void variableTestUnknownVariableKey(){
         Variable<Boolean> var = client.variable(getUser(), "some-var-that-doesnt-exist", true);

--- a/src/test/java/com/devcycle/sdk/server/local/DVCLocalClientTest.java
+++ b/src/test/java/com/devcycle/sdk/server/local/DVCLocalClientTest.java
@@ -267,6 +267,23 @@ public class DVCLocalClientTest {
         client.setClientCustomData(testData);
     }
 
+    @Test
+    public void setClientCustomDataWithBucketing() {
+        DVCLocalClient myClient = createClient(TestDataFixtures.SmallConfigWithCustomDataBucketing());
+
+        // set the global custom data
+        Map<String,Object> customData = new HashMap();
+        customData.put("should-bucket", true);
+        myClient.setClientCustomData(customData);
+
+        // make sure the user get bucketed correctly based on the global custom data
+        User user = getUser();
+        Variable<String> var = myClient.variable(user, "unicode-var", "default string");
+        Assert.assertNotNull(var);
+        Assert.assertFalse(var.getIsDefaulted());
+        Assert.assertEquals("↑↑↓↓←→←→BA 🤖", var.getValue());
+    }
+
     private User getUser() {
         return User.builder()
                 .userId("j_test")

--- a/src/test/resources/fixture_small_config_custom_data_bucketing.json
+++ b/src/test/resources/fixture_small_config_custom_data_bucketing.json
@@ -1,0 +1,227 @@
+{
+  "project": {
+    "_id": "638680c459f1b81cc9e6c557",
+    "key": "test-harness-data",
+    "a0_organization": "org_fakeorg",
+    "settings": {
+      "edgeDB": {
+        "enabled": false
+      },
+      "optIn": {
+        "enabled": false,
+        "colors": {
+          "primary": "#000000",
+          "secondary": "#000000"
+        }
+      }
+    }
+  },
+  "environment": {
+    "_id": "638680c459f1b81cc9e6c559",
+    "key": "development"
+  },
+  "features": [
+    {
+      "_id": "638680d6fcb67b96878d90e6",
+      "key": "test-harness",
+      "type": "release",
+      "variations": [
+        {
+          "key": "variation-on",
+          "name": "Variation On",
+          "variables": [
+            {
+              "_var": "638681f059f1b81cc9e6c7fa",
+              "value": true
+            },
+            {
+              "_var": "638681f059f1b81cc9e6c7fb",
+              "value": "string"
+            },
+            {
+              "_var": "638681f059f1b81cc9e6c7fc",
+              "value": 1
+            },
+            {
+              "_var": "638681f059f1b81cc9e6c7fd",
+              "value": {
+                "facts": true
+              }
+            },
+            {
+              "_var": "638681f059f1b81cc9e6c7fe",
+              "value": "↑↑↓↓←→←→BA 🤖"
+            }
+          ],
+          "_id": "638680d6fcb67b96878d90ec"
+        },
+        {
+          "key": "variation-off",
+          "name": "Variation Off",
+          "variables": [
+            {
+              "_var": "638681f059f1b81cc9e6c7fa",
+              "value": false
+            },
+            {
+              "_var": "638681f059f1b81cc9e6c7fb",
+              "value": "string-off"
+            },
+            {
+              "_var": "638681f059f1b81cc9e6c7fc",
+              "value": 2
+            },
+            {
+              "_var": "638681f059f1b81cc9e6c7fd",
+              "value": {
+                "facts": false
+              }
+            },
+            {
+              "_var": "638681f059f1b81cc9e6c7fe",
+              "value": "🙃"
+            }
+          ],
+          "_id": "638680d6fcb67b96878d90ed"
+        }
+      ],
+      "configuration": {
+        "_id": "638680d659f1b81cc9e6c5a8",
+        "targets": [
+          {
+            "_audience": {
+              "_id": "638680d659f1b81cc9e6c5a9",
+              "filters": {
+                "filters": [
+                  {
+                    "type": "user",
+                    "subType": "customData",
+                    "comparator": "=",
+                    "dataKey": "should-bucket",
+                    "dataKeyType": "Boolean",
+                    "values": [
+                      true
+                    ],
+                    "filters": []
+                  }
+                ],
+                "operator": "or"
+              }
+            },
+            "distribution": [
+              {
+                "_variation": "638680d6fcb67b96878d90ec",
+                "percentage": 1
+              }
+            ],
+            "_id": "638680d659f1b81cc9e6c5ab"
+          }
+        ],
+        "forcedUsers": {}
+      }
+    },
+    {
+      "_id": "6386813a59f1b81cc9e6c68d",
+      "key": "schedule-feature",
+      "type": "release",
+      "variations": [
+        {
+          "key": "variation-on",
+          "name": "Variation On",
+          "variables": [
+            {
+              "_var": "6386813a59f1b81cc9e6c68f",
+              "value": true
+            }
+          ],
+          "_id": "6386813a59f1b81cc9e6c693"
+        },
+        {
+          "key": "variation-off",
+          "name": "Variation Off",
+          "variables": [
+            {
+              "_var": "6386813a59f1b81cc9e6c68f",
+              "value": false
+            }
+          ],
+          "_id": "6386813a59f1b81cc9e6c694"
+        }
+      ],
+      "configuration": {
+        "_id": "6386813a59f1b81cc9e6c6b0",
+        "targets": [
+          {
+            "_audience": {
+              "_id": "6386813a59f1b81cc9e6c6b1",
+              "filters": {
+                "filters": [
+                  {
+                    "type": "all",
+                    "values": [],
+                    "filters": []
+                  }
+                ],
+                "operator": "and"
+              }
+            },
+            "distribution": [
+              {
+                "_variation": "6386813a59f1b81cc9e6c693",
+                "percentage": 1
+              }
+            ],
+            "_id": "6386813a59f1b81cc9e6c6b6"
+          }
+        ],
+        "forcedUsers": {}
+      }
+    }
+  ],
+  "variables": [
+    {
+      "_id": "638681f059f1b81cc9e6c7fa",
+      "key": "bool-var",
+      "type": "Boolean"
+    },
+    {
+      "_id": "638681f059f1b81cc9e6c7fd",
+      "key": "json-var",
+      "type": "JSON"
+    },
+    {
+      "_id": "638681f059f1b81cc9e6c7fc",
+      "key": "number-var",
+      "type": "Number"
+    },
+    {
+      "_id": "6386813a59f1b81cc9e6c68f",
+      "key": "schedule-feature",
+      "type": "Boolean"
+    },
+    {
+      "_id": "638681f059f1b81cc9e6c7fb",
+      "key": "string-var",
+      "type": "String"
+    },
+    {
+      "_id": "638680d6fcb67b96878d90e8",
+      "key": "test-harness",
+      "type": "Boolean"
+    },
+    {
+      "_id": "638681f059f1b81cc9e6c7fe",
+      "key": "unicode-var",
+      "type": "String"
+    }
+  ],
+  "variableHashes": {
+    "bool-var": 4169114058,
+    "json-var": 911896931,
+    "number-var": 2467683513,
+    "schedule-feature": 66456795,
+    "string-var": 2413071944,
+    "test-harness": 1034405338,
+    "unicode-var": 2917818241
+  }
+}


### PR DESCRIPTION
There was a bug in the creation of the protobuf user object where the privateCustomData map would overwrite the customData map property. This causes bucketing depending on customData properties to fail.

Also added some unit tests around the setting and evaluation of custom data for bucketing.