### PR TITLE
DVC-7512 - fix UTF8 issues with generateBucketConfigForUser

### DIFF
--- a/src/main/java/com/devcycle/sdk/server/local/bucketing/LocalBucketing.java
+++ b/src/main/java/com/devcycle/sdk/server/local/bucketing/LocalBucketing.java
@@ -235,14 +235,16 @@ public class LocalBucketing {
         String userString = OBJECT_MAPPER.writeValueAsString(user);
 
         int sdkKeyAddress = getSDKKeyAddress(sdkKey);
-        int userAddress = newWasmString(userString);
+        int userAddress = newUint8ArrayParameter(userString.getBytes(StandardCharsets.UTF_8));
 
-        Func generateBucketedConfigForUserPtr = linker.get(store, "", "generateBucketedConfigForUser").get().func();
+        Func generateBucketedConfigForUserPtr = linker.get(store, "", "generateBucketedConfigForUserUTF8").get().func();
         WasmFunctions.Function2<Integer, Integer, Integer> generateBucketedConfigForUser = WasmFunctions.func(
                 store, generateBucketedConfigForUserPtr, I32, I32, I32);
 
         int resultAddress = generateBucketedConfigForUser.call(sdkKeyAddress, userAddress);
-        String bucketedConfigString = readWasmString(resultAddress);
+
+        byte[] bucketConfigBytes = readAssemblyScriptUint8Array(resultAddress);
+        String bucketedConfigString = new String(bucketConfigBytes, StandardCharsets.UTF_8);
 
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/src/test/java/com/devcycle/sdk/server/local/DVCLocalClientTest.java
+++ b/src/test/java/com/devcycle/sdk/server/local/DVCLocalClientTest.java
@@ -268,7 +268,7 @@ public class DVCLocalClientTest {
     }
 
     @Test
-    public void setClientCustomDataWithBucketing() {
+    public void SetClientCustomDataWithBucketingTest() {
         DVCLocalClient myClient = createClient(TestDataFixtures.SmallConfigWithCustomDataBucketing());
 
         // set the global custom data
@@ -282,6 +282,16 @@ public class DVCLocalClientTest {
         Assert.assertNotNull(var);
         Assert.assertFalse(var.getIsDefaulted());
         Assert.assertEquals("↑↑↓↓←→←→BA 🤖", var.getValue());
+    }
+
+    @Test
+    public void allFeaturesWithSpecialCharsTest() {
+        DVCLocalClient myClient = createClient(TestDataFixtures.SmallConfigWithSpecialCharacters());
+        // make sure the user get bucketed correctly based on the global custom data
+        User user = getUser();
+        Map<String,Feature> features = myClient.allFeatures(user);
+        Assert.assertNotNull(features);
+        Assert.assertEquals(features.size(), 1);
     }
 
     private User getUser() {


### PR DESCRIPTION
fixed the generateBucketedConfigForUser to use the UTF8 version of the WASM function to match the rest of the UTF8 support in LocalBucketing.java