### PR TITLE
Add customizable logging system

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Then you can set the logger into the Java Server SDK setting the Custom Logger p
 initialize the client.
 
 ```java
+
+```java
 // Create your logging wrapper
 IDVCLogger loggingWrapper = new IDVCLogger() {
     @Override
@@ -118,3 +120,5 @@ DVCLocalClient dvcClient = new DVCLocalClient("YOUR_DVC_SERVER_SDK_KEY", options
 DVCCloudOptions options = DVCCloudOptions.builder().customLogger(loggingWrapper).build();
 DVCCloudClient dvcClient = new DVCCloudClient("YOUR_DVC_SERVER_SDK_KEY", options);
 ```
+
+You can also disable all logging by setting the custom logger to `new SimpleDVCLogger(SimpleDVCLogger.Level.OFF)`.

--- a/README.md
+++ b/README.md
@@ -79,3 +79,42 @@ public class MyClass {
 
 To find usage documentation, visit our docs for [Local Bucketing](https://docs.devcycle.com/docs/sdk/server-side-sdks/java-local).
 
+## Logging
+
+The DevCycle SDK logs to **stdout** by default and does not require any specific logging package. To integrate with your 
+own logging system, such as Java Logging or SLF4J, you can create a wrapper that implements the `IDVCLogger` interface. 
+Then you can set the logger into the Java Server SDK setting the Custom Logger property in the options object used to 
+initialize the client.
+
+```java
+// Create your logging wrapper
+IDVCLogger loggingWrapper = new IDVCLogger() {
+    @Override
+    public void debug(String message) {
+        // Your logging implementation here
+    }
+
+    @Override
+    public void info(String message) {
+        // Your logging implementation here
+    }
+
+    @Override
+    public void warn(String message) {
+        // Your logging implementation here
+    }
+
+    @Override
+    public void error(String message) {
+        // Your logging implementation here
+    }
+};
+
+// Set the logger in the options before creating the DVCLocalClient
+DVCLocalOptions options = DVCLocalOptions.builder().customLogger(loggingWrapper).build();
+DVCLocalClient dvcClient = new DVCLocalClient("YOUR_DVC_SERVER_SDK_KEY", options);
+
+// Or for DVCCloudClient
+DVCCloudOptions options = DVCCloudOptions.builder().customLogger(loggingWrapper).build();
+DVCCloudClient dvcClient = new DVCCloudClient("YOUR_DVC_SERVER_SDK_KEY", options);
+```

--- a/src/main/java/com/devcycle/sdk/server/cloud/api/DVCCloudClient.java
+++ b/src/main/java/com/devcycle/sdk/server/cloud/api/DVCCloudClient.java
@@ -3,6 +3,7 @@ package com.devcycle.sdk.server.cloud.api;
 import com.devcycle.sdk.server.cloud.model.DVCCloudOptions;
 import com.devcycle.sdk.server.common.api.IDVCApi;
 import com.devcycle.sdk.server.common.exception.DVCException;
+import com.devcycle.sdk.server.common.logging.DVCLogger;
 import com.devcycle.sdk.server.common.model.*;
 import com.devcycle.sdk.server.common.model.Variable.TypeEnum;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -35,6 +36,11 @@ public final class DVCCloudClient {
 
     if(!isValidServerKey(sdkKey)) {
       throw new IllegalArgumentException("Invalid environment key provided. Please call initialize with a valid server environment key");
+    }
+
+    if(options.getCustomLogger() != null)
+    {
+        DVCLogger.setCustomLogger(options.getCustomLogger());
     }
 
     this.dvcOptions = options;

--- a/src/main/java/com/devcycle/sdk/server/cloud/model/DVCCloudOptions.java
+++ b/src/main/java/com/devcycle/sdk/server/cloud/model/DVCCloudOptions.java
@@ -1,5 +1,6 @@
 package com.devcycle.sdk.server.cloud.model;
 
+import com.devcycle.sdk.server.common.logging.IDVCLogger;
 import com.devcycle.sdk.server.common.model.IDVCOptions;
 
 import lombok.Builder;
@@ -13,6 +14,9 @@ public class DVCCloudOptions {
 
     @Builder.Default
     private String baseURLOverride = null;
+
+    @Builder.Default
+    private IDVCLogger customLogger = null;
 
     public static class DVCCloudOptionsBuilder implements IDVCOptions { }
 }

--- a/src/main/java/com/devcycle/sdk/server/common/logging/DVCLogger.java
+++ b/src/main/java/com/devcycle/sdk/server/common/logging/DVCLogger.java
@@ -1,0 +1,42 @@
+package com.devcycle.sdk.server.common.logging;
+/**
+ * DVCLogger is a simple central entrypoint for the SDK to log messages without pinning the SDK to a
+ * specific logging framework. By default it logs to stdout but can e overriden by calling setCustomLogger()
+ */
+public class DVCLogger {
+    private static IDVCLogger logger = new SimpleDVCLogger(SimpleDVCLogger.Level.INFO);
+    public static void setCustomLogger(IDVCLogger logger) {
+        DVCLogger.logger = logger;
+    }
+
+    public static void debug(String message) {
+        if(logger != null){
+            logger.debug(message);
+        }
+    }
+
+    public static void info(String message) {
+        if(logger != null) {
+            logger.info(message);
+        }
+    }
+
+    public static void warning(String message) {
+        if(logger != null) {
+            logger.warning(message);
+        }
+    }
+
+    public static void error(String message) {
+            if(logger != null) {
+                logger.error(message);
+            }
+    }
+
+    public static void error(String message, Throwable t) {
+            if(logger != null) {
+                logger.error(message, t);
+            }
+    }
+}
+

--- a/src/main/java/com/devcycle/sdk/server/common/logging/IDVCLogger.java
+++ b/src/main/java/com/devcycle/sdk/server/common/logging/IDVCLogger.java
@@ -1,0 +1,13 @@
+package com.devcycle.sdk.server.common.logging;
+
+/**
+ * A simple interface for logging inside the SDK. Implement this interface and pass it to the SDK to override the
+ * default behavior. Use this interface to integrate with an existing logging framework such as Java Logging, Log4j or SLF4J
+ */
+public interface IDVCLogger {
+    void debug(String message);
+    void info(String message);
+    void warning(String message);
+    void error(String message);
+    void error(String message, Throwable t);
+}

--- a/src/main/java/com/devcycle/sdk/server/common/logging/SimpleDVCLogger.java
+++ b/src/main/java/com/devcycle/sdk/server/common/logging/SimpleDVCLogger.java
@@ -9,7 +9,7 @@ public class SimpleDVCLogger implements IDVCLogger {
         INFO,
         WARNING,
         ERROR,
-        NONE,
+        OFF,
     }
     private Level level;
     public SimpleDVCLogger(Level level) {

--- a/src/main/java/com/devcycle/sdk/server/common/logging/SimpleDVCLogger.java
+++ b/src/main/java/com/devcycle/sdk/server/common/logging/SimpleDVCLogger.java
@@ -1,0 +1,54 @@
+package com.devcycle.sdk.server.common.logging;
+
+/**
+ * Basic implementation of IDVCLogger that logs to stdout with some basic log level filtering.
+ */
+public class SimpleDVCLogger implements IDVCLogger {
+    public enum Level {
+        DEBUG,
+        INFO,
+        WARNING,
+        ERROR,
+        NONE,
+    }
+    private Level level;
+    public SimpleDVCLogger(Level level) {
+        this.level = level;
+    }
+
+    @Override
+    public void debug(String message) {
+        if(this.level.ordinal() == Level.DEBUG.ordinal())
+        {
+            System.out.println(message);
+        }
+    }
+
+    @Override
+    public void info(String message) {
+        if(this.level.ordinal() <= Level.INFO.ordinal()) {
+            System.out.println(message);
+        }
+    }
+
+    @Override
+    public void warning(String message) {
+        if(this.level.ordinal() <= Level.WARNING.ordinal()) {
+            System.out.println(message);
+        }
+    }
+
+    @Override
+    public void error(String message) {
+        if(this.level.ordinal() <= Level.ERROR.ordinal()) {
+            System.out.println(message);
+        }
+    }
+
+    @Override
+    public void error(String message, Throwable t) {
+        if(this.level.ordinal() <= Level.ERROR.ordinal()) {
+            System.out.println(message);
+        }
+    }
+}

--- a/src/main/java/com/devcycle/sdk/server/common/model/PlatformData.java
+++ b/src/main/java/com/devcycle/sdk/server/common/model/PlatformData.java
@@ -11,12 +11,15 @@ import lombok.Data;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @Data
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 
 public class PlatformData {
+    private Logger logger = Logger.getLogger(PlatformData.class.getName());
     public PlatformData(String platform, String platformVersion, SdkTypeEnum sdkType, String sdkVersion, String hostname) {
         this.platform = platform;
         this.platformVersion = platformVersion;
@@ -25,7 +28,7 @@ public class PlatformData {
         try {
             this.hostname = hostname != null ? hostname : InetAddress.getLocalHost().getHostName();
         } catch (UnknownHostException e) {
-            System.out.println("Error getting hostname: " + e.getMessage());
+            logger.info("Error getting system hostname: " + e.getMessage());
             this.hostname = "";
         }
     }
@@ -64,7 +67,7 @@ public class PlatformData {
             mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
             platformDataString = mapper.writeValueAsString(platformData);
         } catch (JsonProcessingException e) {
-            System.out.println("Error reading platformData: " + e.getMessage());
+            logger.log(Level.FINEST, "Error reading platformData: " + e.getMessage());
         }
         return platformDataString;
     }

--- a/src/main/java/com/devcycle/sdk/server/common/model/PlatformData.java
+++ b/src/main/java/com/devcycle/sdk/server/common/model/PlatformData.java
@@ -17,9 +17,7 @@ import java.util.logging.Logger;
 @Data
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
-
 public class PlatformData {
-    private Logger logger = Logger.getLogger(PlatformData.class.getName());
     public PlatformData(String platform, String platformVersion, SdkTypeEnum sdkType, String sdkVersion, String hostname) {
         this.platform = platform;
         this.platformVersion = platformVersion;
@@ -28,7 +26,7 @@ public class PlatformData {
         try {
             this.hostname = hostname != null ? hostname : InetAddress.getLocalHost().getHostName();
         } catch (UnknownHostException e) {
-            logger.info("Error getting system hostname: " + e.getMessage());
+            System.out.println("Error getting system hostname: " + e.getMessage());
             this.hostname = "";
         }
     }
@@ -67,7 +65,7 @@ public class PlatformData {
             mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
             platformDataString = mapper.writeValueAsString(platformData);
         } catch (JsonProcessingException e) {
-            logger.log(Level.FINEST, "Error reading platformData: " + e.getMessage());
+            System.out.println("Error reading platformData: " + e.getMessage());
         }
         return platformDataString;
     }

--- a/src/main/java/com/devcycle/sdk/server/common/model/PlatformData.java
+++ b/src/main/java/com/devcycle/sdk/server/common/model/PlatformData.java
@@ -1,5 +1,6 @@
 package com.devcycle.sdk.server.common.model;
 
+import com.devcycle.sdk.server.common.logging.DVCLogger;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -26,7 +27,7 @@ public class PlatformData {
         try {
             this.hostname = hostname != null ? hostname : InetAddress.getLocalHost().getHostName();
         } catch (UnknownHostException e) {
-            System.out.println("Error getting system hostname: " + e.getMessage());
+            DVCLogger.warning("Error getting system hostname: " + e.getMessage());
             this.hostname = "";
         }
     }
@@ -65,7 +66,7 @@ public class PlatformData {
             mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
             platformDataString = mapper.writeValueAsString(platformData);
         } catch (JsonProcessingException e) {
-            System.out.println("Error reading platformData: " + e.getMessage());
+            DVCLogger.warning("Error reading platformData: " + e.getMessage());
         }
         return platformDataString;
     }

--- a/src/main/java/com/devcycle/sdk/server/local/bucketing/LocalBucketing.java
+++ b/src/main/java/com/devcycle/sdk/server/local/bucketing/LocalBucketing.java
@@ -1,5 +1,6 @@
 package com.devcycle.sdk.server.local.bucketing;
 
+import com.devcycle.sdk.server.common.logging.DVCLogger;
 import com.devcycle.sdk.server.common.model.User;
 import com.devcycle.sdk.server.common.model.Variable;
 import com.devcycle.sdk.server.local.model.BucketedUserConfig;
@@ -80,7 +81,7 @@ public class LocalBucketing {
 
         Func consoleLogFn = WasmFunctions.wrap(store, I32, (addr) -> {
             String message = readWasmString(((Number) addr).intValue());
-            logger.log(Level.WARNING, "WASM error: " + message);
+            DVCLogger.warning("WASM error: " + message);
         });
         linker.define("env", "console.log", Extern.fromFunc(consoleLogFn));
 

--- a/src/main/java/com/devcycle/sdk/server/local/bucketing/LocalBucketing.java
+++ b/src/main/java/com/devcycle/sdk/server/local/bucketing/LocalBucketing.java
@@ -20,6 +20,8 @@ import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static io.github.kawamuray.wasmtime.WasmValType.F64;
 import static io.github.kawamuray.wasmtime.WasmValType.I32;
@@ -37,6 +39,8 @@ public class LocalBucketing {
 
     private final int WASM_OBJECT_ID_STRING = 1;
     private final int WASM_OBJECT_ID_UINT8ARRAY = 9;
+
+    private Logger logger = Logger.getLogger(LocalBucketing.class.getName());
 
     public LocalBucketing() {
         OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
@@ -76,7 +80,7 @@ public class LocalBucketing {
 
         Func consoleLogFn = WasmFunctions.wrap(store, I32, (addr) -> {
             String message = readWasmString(((Number) addr).intValue());
-            System.out.println(message);
+            logger.log(Level.WARNING, "WASM error: " + message);
         });
         linker.define("env", "console.log", Extern.fromFunc(consoleLogFn));
 

--- a/src/main/java/com/devcycle/sdk/server/local/model/DVCLocalOptions.java
+++ b/src/main/java/com/devcycle/sdk/server/local/model/DVCLocalOptions.java
@@ -1,11 +1,10 @@
 package com.devcycle.sdk.server.local.model;
 
 import com.devcycle.sdk.server.common.model.IDVCOptions;
-
+import com.devcycle.sdk.server.common.logging.DVCLogger;
+import com.devcycle.sdk.server.common.logging.IDVCLogger;
 import lombok.Builder;
 import lombok.Data;
-
-import java.util.logging.Logger;
 
 @Data
 public class DVCLocalOptions implements IDVCOptions {
@@ -27,6 +26,8 @@ public class DVCLocalOptions implements IDVCOptions {
 
     private boolean disableAutomaticEventLogging = false;
 
+    private IDVCLogger customLogger = null;
+
     public int getConfigPollingIntervalMS(int configPollingIntervalMs, int configPollingIntervalMS) {
         if (configPollingIntervalMS > 0) {
             return configPollingIntervalMS;
@@ -38,8 +39,6 @@ public class DVCLocalOptions implements IDVCOptions {
     }
 
     private boolean disableCustomEventLogging = false;
-
-    private Logger logger = Logger.getLogger(DVCLocalOptions.class.getName());
 
     @Builder()
     public DVCLocalOptions(
@@ -54,7 +53,8 @@ public class DVCLocalOptions implements IDVCOptions {
             int maxEventQueueSize,
             int eventRequestChunkSize,
             boolean disableAutomaticEventLogging,
-            boolean disableCustomEventLogging
+            boolean disableCustomEventLogging,
+            IDVCLogger customLogger
     ) {
         this.configRequestTimeoutMs = configRequestTimeoutMs > 0 ? configRequestTimeoutMs : this.configRequestTimeoutMs;
         this.configPollingIntervalMS = getConfigPollingIntervalMS(configPollingIntervalMs, configPollingIntervalMS);
@@ -66,29 +66,30 @@ public class DVCLocalOptions implements IDVCOptions {
         this.eventRequestChunkSize = eventRequestChunkSize > 0 ? eventRequestChunkSize : this.eventRequestChunkSize;
         this.disableAutomaticEventLogging = disableAutomaticEventLogging;
         this.disableCustomEventLogging = disableCustomEventLogging;
+        this.customLogger = customLogger;
 
         if (this.flushEventQueueSize >= this.maxEventQueueSize) {
-            logger.warning("flushEventQueueSize: " + this.flushEventQueueSize + " must be smaller than maxEventQueueSize: " + this.maxEventQueueSize);
+            DVCLogger.warning("flushEventQueueSize: " + this.flushEventQueueSize + " must be smaller than maxEventQueueSize: " + this.maxEventQueueSize);
             this.flushEventQueueSize = this.maxEventQueueSize - 1;
         }
 
         if (this.eventRequestChunkSize > this.flushEventQueueSize) {
-            logger.warning("eventRequestChunkSize: " + this.eventRequestChunkSize + " must be smaller than flushEventQueueSize: " + this.flushEventQueueSize);
+            DVCLogger.warning("eventRequestChunkSize: " + this.eventRequestChunkSize + " must be smaller than flushEventQueueSize: " + this.flushEventQueueSize);
             this.eventRequestChunkSize = 100;
         }
 
         if (this.eventRequestChunkSize > this.maxEventQueueSize) {
-            logger.warning("eventRequestChunkSize: " + this.eventRequestChunkSize + " must be smaller than maxEventQueueSize: " + this.maxEventQueueSize);
+            DVCLogger.warning("eventRequestChunkSize: " + this.eventRequestChunkSize + " must be smaller than maxEventQueueSize: " + this.maxEventQueueSize);
             this.eventRequestChunkSize = 100;
         }
 
         if (this.flushEventQueueSize > 20000) {
-            logger.warning("flushEventQueueSize: " + this.flushEventQueueSize + " must be smaller than 20,000");
+            DVCLogger.warning("flushEventQueueSize: " + this.flushEventQueueSize + " must be smaller than 20,000");
             this.flushEventQueueSize = 20000;
         }
 
         if (this.maxEventQueueSize > 20000) {
-            logger.warning("maxEventQueueSize: " + this.maxEventQueueSize + " must be smaller than 20,000");
+            DVCLogger.warning("maxEventQueueSize: " + this.maxEventQueueSize + " must be smaller than 20,000");
             this.maxEventQueueSize = 20000;
         }
     }

--- a/src/main/java/com/devcycle/sdk/server/local/model/DVCLocalOptions.java
+++ b/src/main/java/com/devcycle/sdk/server/local/model/DVCLocalOptions.java
@@ -5,6 +5,8 @@ import com.devcycle.sdk.server.common.model.IDVCOptions;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.logging.Logger;
+
 @Data
 public class DVCLocalOptions implements IDVCOptions {
     private int configRequestTimeoutMs = 10000;
@@ -37,6 +39,8 @@ public class DVCLocalOptions implements IDVCOptions {
 
     private boolean disableCustomEventLogging = false;
 
+    private Logger logger = Logger.getLogger(DVCLocalOptions.class.getName());
+
     @Builder()
     public DVCLocalOptions(
             int configRequestTimeoutMs,
@@ -64,27 +68,27 @@ public class DVCLocalOptions implements IDVCOptions {
         this.disableCustomEventLogging = disableCustomEventLogging;
 
         if (this.flushEventQueueSize >= this.maxEventQueueSize) {
-            System.out.println("flushEventQueueSize: " + this.flushEventQueueSize + " must be smaller than maxEventQueueSize: " + this.maxEventQueueSize);
+            logger.warning("flushEventQueueSize: " + this.flushEventQueueSize + " must be smaller than maxEventQueueSize: " + this.maxEventQueueSize);
             this.flushEventQueueSize = this.maxEventQueueSize - 1;
         }
 
         if (this.eventRequestChunkSize > this.flushEventQueueSize) {
-            System.out.println("eventRequestChunkSize: " + this.eventRequestChunkSize + " must be smaller than flushEventQueueSize: " + this.flushEventQueueSize);
+            logger.warning("eventRequestChunkSize: " + this.eventRequestChunkSize + " must be smaller than flushEventQueueSize: " + this.flushEventQueueSize);
             this.eventRequestChunkSize = 100;
         }
 
         if (this.eventRequestChunkSize > this.maxEventQueueSize) {
-            System.out.println("eventRequestChunkSize: " + this.eventRequestChunkSize + " must be smaller than maxEventQueueSize: " + this.maxEventQueueSize);
+            logger.warning("eventRequestChunkSize: " + this.eventRequestChunkSize + " must be smaller than maxEventQueueSize: " + this.maxEventQueueSize);
             this.eventRequestChunkSize = 100;
         }
 
         if (this.flushEventQueueSize > 20000) {
-            System.out.println("flushEventQueueSize: " + this.flushEventQueueSize + " must be smaller than 20,000");
+            logger.warning("flushEventQueueSize: " + this.flushEventQueueSize + " must be smaller than 20,000");
             this.flushEventQueueSize = 20000;
         }
 
         if (this.maxEventQueueSize > 20000) {
-            System.out.println("maxEventQueueSize: " + this.maxEventQueueSize + " must be smaller than 20,000");
+            logger.warning("maxEventQueueSize: " + this.maxEventQueueSize + " must be smaller than 20,000");
             this.maxEventQueueSize = 20000;
         }
     }

--- a/src/test/java/com/devcycle/sdk/server/local/DVCLocalClientTest.java
+++ b/src/test/java/com/devcycle/sdk/server/local/DVCLocalClientTest.java
@@ -39,6 +39,7 @@ public class DVCLocalClientTest {
                 .configCdnBaseUrl("http://localhost:8000/")
                 .configPollingIntervalMS(60000)
                 .build();
+
         DVCLocalClient client = new DVCLocalClient(apiKey, options);
         try {
             int loops = 0;


### PR DESCRIPTION
Introduced a custom logging system that still defaults to **stdout**, but is easy for any dev to override and customize. 

Given that there a half dozen "standard" packages for logging in Java with mixed interoperability, I didn't want to create a dependency for one of them in the SDK. Instead I added a simple interface that users can implement in order to redirect the SDKs log output to their own internal logging system such as Java Logging, log4j2, SLF4J, etc

This mimics a similar system we provide in the Go SDK