### PR TITLE
Update wasmtime dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can use the SDK in your Maven project by adding the following to your *pom.x
 <dependency>
     <groupId>com.devcycle</groupId>
     <artifactId>java-server-sdk</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <scope>compile</scope>
 </dependency>
 ```
@@ -35,7 +35,7 @@ You can use the SDK in your Maven project by adding the following to your *pom.x
 Alternatively you can use the SDK in your Gradle project by adding the following to *build.gradle*:
 
 ```yaml
-implementation("com.devcycle:java-server-sdk:1.6.0")
+implementation("com.devcycle:java-server-sdk:1.6.1")
 ```
 
 ## DNS Caching

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -64,7 +64,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jmh.version>1.36</jmh.version>
         <javac.target>1.8</javac.target>
-        <java.server.sdk.version>1.6.0</java.server.sdk.version>
+        <java.server.sdk.version>1.6.1</java.server.sdk.version>
         <uberjar.name>java-server-sdk-benchmarks</uberjar.name>
     </properties>
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ signing {
 
 group = "com.devcycle"
 archivesBaseName = "java-server-sdk"
-version = "1.6.0"
+version = "1.6.1"
 
 publishing {
     publications {
@@ -112,7 +112,7 @@ ext {
     swagger_annotations_version = "2.2.0"
     lombok_version = "1.18.24"
     okhttp_version = "4.9.3"
-    wasmtime_version = "0.14.0"
+    wasmtime_version = "0.15.0"
 
     junit_version = "4.13.2"
     mockito_core_version = "4.6.1"

--- a/example-cloud/build.gradle
+++ b/example-cloud/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 	compileOnly('org.projectlombok:lombok:1.18.24')
 
 	// The line below makes the Example App use the production build of the Java Server SDK
-	implementation("com.devcycle:java-server-sdk:1.6.0")
+	implementation("com.devcycle:java-server-sdk:1.6.1")
 
 	// The line below makes the Example App use the local version of the Java Server SDK
 	// Run `./gradlew build` in the root directory (`cd .. && ./gradlew build`) to build the local version of the SDK

--- a/example-local/build.gradle
+++ b/example-local/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 	compileOnly('org.projectlombok:lombok:1.18.24')
 
 	// The line below makes the Example App use the production build of the Java Server SDK
-	 implementation("com.devcycle:java-server-sdk:1.6.0")
+	 implementation("com.devcycle:java-server-sdk:1.6.1")
 
 	// The line below makes the Example App use the local version of the Java Server SDK
 	// Run `./gradlew build` in the root directory (`cd .. && ./gradlew build`) to build the local version of the SDK

--- a/src/main/java/com/devcycle/sdk/server/common/model/PlatformData.java
+++ b/src/main/java/com/devcycle/sdk/server/common/model/PlatformData.java
@@ -46,7 +46,7 @@ public class PlatformData {
 
     @Schema(description = "DevCycle SDK Version")
     @Builder.Default
-    private String sdkVersion = "1.6.0";
+    private String sdkVersion = "1.6.1";
 
     @Schema(description = "Hostname where the SDK is running")
     private String hostname;

--- a/src/test/java/com/devcycle/sdk/server/cloud/DVCCloudClientTest.java
+++ b/src/test/java/com/devcycle/sdk/server/cloud/DVCCloudClientTest.java
@@ -200,6 +200,6 @@ public class DVCCloudClientTest {
         Assert.assertEquals("Java", user.getPlatform());
         Assert.assertEquals(PlatformData.SdkTypeEnum.SERVER, user.getSdkType());
         Assert.assertNotNull(user.getPlatformVersion());
-        Assert.assertEquals("1.6.0", user.getSdkVersion());
+        Assert.assertEquals("1.6.1", user.getSdkVersion());
     }
 }


### PR DESCRIPTION
- updated wasmtime to 0.15.0 in order to reduce `glibc` requirement to 2.30 and make local bucketing more compatible
- bumped sdk version to 1.6.1