### PR TITLE
[fix] Setting custom logger on DVCLocalClient causes exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,21 @@ This version of the DevCycle SDK works with Java 8 and above.
 
 Using the Java SDK library requires [Maven](https://maven.apache.org/) or [Gradle](https://gradle.org/) >= 7.6+ to be installed.
 
-An x86_64 JDK is required for Local Bucketing with the DevCycle Java SDK. Currently Supported Platforms are:
+An x86_64 JDK is required for Local Bucketing with the DevCycle Java SDK. 
+
+Currently Supported Platforms are:
 
 | OS | Arch |
 | --- | --- |
 | Linux (ELF) | x86_64 |
 | Mac OS | x86_64 |
 | Windows | x86_64 |
+
+In addition, the environment must support GLIBC v2.32 or higher.  You can use the following command to check your GLIBC version:
+
+```bash
+ldd --version
+``` 
 
 ## Installation
 
@@ -102,12 +110,17 @@ IDVCLogger loggingWrapper = new IDVCLogger() {
     }
 
     @Override
-    public void warn(String message) {
+    public void warning(String message) {
         // Your logging implementation here
     }
 
     @Override
     public void error(String message) {
+        // Your logging implementation here
+    }
+
+    @Override
+    public void error(String message, Throwable throwable) {
         // Your logging implementation here
     }
 };

--- a/src/main/java/com/devcycle/sdk/server/local/model/DVCLocalOptions.java
+++ b/src/main/java/com/devcycle/sdk/server/local/model/DVCLocalOptions.java
@@ -3,6 +3,7 @@ package com.devcycle.sdk.server.local.model;
 import com.devcycle.sdk.server.common.model.IDVCOptions;
 import com.devcycle.sdk.server.common.logging.DVCLogger;
 import com.devcycle.sdk.server.common.logging.IDVCLogger;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Data;
 
@@ -26,6 +27,7 @@ public class DVCLocalOptions implements IDVCOptions {
 
     private boolean disableAutomaticEventLogging = false;
 
+    @JsonIgnore
     private IDVCLogger customLogger = null;
 
     public int getConfigPollingIntervalMS(int configPollingIntervalMs, int configPollingIntervalMS) {

--- a/src/test/java/com/devcycle/sdk/server/local/DVCLocalClientTest.java
+++ b/src/test/java/com/devcycle/sdk/server/local/DVCLocalClientTest.java
@@ -1,5 +1,6 @@
 package com.devcycle.sdk.server.local;
 
+import com.devcycle.sdk.server.common.logging.IDVCLogger;
 import com.devcycle.sdk.server.common.model.BaseVariable;
 import com.devcycle.sdk.server.common.model.Feature;
 import com.devcycle.sdk.server.common.model.User;
@@ -25,6 +26,33 @@ public class DVCLocalClientTest {
     private static LocalConfigServer localConfigServer;
     static final String apiKey = String.format("server-%s", UUID.randomUUID());
 
+    static IDVCLogger testLoggingWrapper = new IDVCLogger() {
+        @Override
+        public void debug(String message) {
+            System.out.println("DEBUG TEST: " + message);
+        }
+
+        @Override
+        public void info(String message) {
+            System.out.println("INFO TEST: " + message);
+        }
+
+        @Override
+        public void warning(String message) {
+            System.out.println("WARN TEST: " + message);
+        }
+
+        @Override
+        public void error(String message) {
+            System.out.println("ERROR TEST: " + message);
+        }
+
+        @Override
+        public void error(String message, Throwable throwable) {
+            System.out.println("ERROR TEST: " + message);
+        }
+    };
+
     @BeforeClass
     public static void setup() throws Exception {
         // spin up a lightweight http server to serve the config and properly initialize the client
@@ -35,9 +63,11 @@ public class DVCLocalClientTest {
 
     private static DVCLocalClient createClient(String config){
         localConfigServer.setConfigData(config);
+
         DVCLocalOptions options = DVCLocalOptions.builder()
                 .configCdnBaseUrl("http://localhost:8000/")
                 .configPollingIntervalMS(60000)
+                .customLogger(testLoggingWrapper)
                 .build();
 
         DVCLocalClient client = new DVCLocalClient(apiKey, options);


### PR DESCRIPTION
Ticket: https://taplytics.atlassian.net/browse/DVC-7985

Setting up custom logging on a DVCLocalClient when events are enabled will cause the client to generate a JSON serialization exception during client creation.  

Added `@JsonIgnore` annotation to the property so it doesn't get included in options serialization during creation of the event queue.

Introduced a custom logger to the DVCLocalClient to ensure it works properly
