### PR TITLE
DVC-8003 custom header and ssl support

### DIFF
--- a/src/main/java/com/devcycle/sdk/server/cloud/api/DVCCloudApiClient.java
+++ b/src/main/java/com/devcycle/sdk/server/cloud/api/DVCCloudApiClient.java
@@ -1,6 +1,7 @@
 package com.devcycle.sdk.server.cloud.api;
 
 import com.devcycle.sdk.server.cloud.model.DVCCloudOptions;
+import com.devcycle.sdk.server.common.api.APIUtils;
 import com.devcycle.sdk.server.common.api.IDVCApi;
 import com.devcycle.sdk.server.common.api.IRestOptions;
 import com.devcycle.sdk.server.common.exception.DVCException;
@@ -35,18 +36,7 @@ public final class DVCCloudApiClient {
     OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     okBuilder = new OkHttpClient.Builder();
 
-    IRestOptions restOptions = options.getRestOptions();
-    if(restOptions != null)
-    {
-      if(restOptions.getHostnameVerifier() != null){
-        okBuilder.hostnameVerifier(restOptions.getHostnameVerifier());
-      }
-
-      if(restOptions.getSocketFactory() != null && restOptions.getTrustManager() != null){
-        okBuilder.sslSocketFactory(restOptions.getSocketFactory(), restOptions.getTrustManager());
-      }
-      okBuilder.addInterceptor(new CustomHeaderInterceptor(restOptions));
-    }
+    APIUtils.applyRestOptions(options.getRestOptions(), okBuilder);
 
     okBuilder.addInterceptor(new AuthorizationHeaderInterceptor(apiKey));
 

--- a/src/main/java/com/devcycle/sdk/server/cloud/api/DVCCloudApiClient.java
+++ b/src/main/java/com/devcycle/sdk/server/cloud/api/DVCCloudApiClient.java
@@ -2,8 +2,10 @@ package com.devcycle.sdk.server.cloud.api;
 
 import com.devcycle.sdk.server.cloud.model.DVCCloudOptions;
 import com.devcycle.sdk.server.common.api.IDVCApi;
+import com.devcycle.sdk.server.common.api.IRestOptions;
 import com.devcycle.sdk.server.common.exception.DVCException;
 import com.devcycle.sdk.server.common.interceptor.AuthorizationHeaderInterceptor;
+import com.devcycle.sdk.server.common.interceptor.CustomHeaderInterceptor;
 import com.devcycle.sdk.server.common.model.HttpResponseCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -29,9 +31,24 @@ public final class DVCCloudApiClient {
   private static final String BUCKETING_URL = "https://bucketing-api.devcycle.com/";
   private String bucketingUrl;
 
-  private DVCCloudApiClient(DVCCloudOptions options) {
+  public DVCCloudApiClient(String apiKey, DVCCloudOptions options) {
     OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     okBuilder = new OkHttpClient.Builder();
+
+    IRestOptions restOptions = options.getRestOptions();
+    if(restOptions != null)
+    {
+      if(restOptions.getHostnameVerifier() != null){
+        okBuilder.hostnameVerifier(restOptions.getHostnameVerifier());
+      }
+
+      if(restOptions.getSocketFactory() != null && restOptions.getTrustManager() != null){
+        okBuilder.sslSocketFactory(restOptions.getSocketFactory(), restOptions.getTrustManager());
+      }
+      okBuilder.addInterceptor(new CustomHeaderInterceptor(restOptions));
+    }
+
+    okBuilder.addInterceptor(new AuthorizationHeaderInterceptor(apiKey));
 
     if (!isStringNullOrEmpty(options.getBaseURLOverride())) {
       bucketingUrl = options.getBaseURLOverride();
@@ -44,27 +61,6 @@ public final class DVCCloudApiClient {
     adapterBuilder = new Retrofit.Builder()
         .baseUrl(bucketingUrl)
         .addConverterFactory(JacksonConverterFactory.create());
-  }
-
-  public DVCCloudApiClient(String apiKey, DVCCloudOptions options) {
-    this(options);
-    okBuilder.addInterceptor(new AuthorizationHeaderInterceptor(apiKey));
-
-    KeyStore keyStore = null;//options.getCustomeCerts(); //todo Load from options
-    String keyStorePass = "keystore_pass"; //todo Load from options
-    SSLContext sslContext = null;
-    try {
-      // example code pulled from: https://stackoverflow.com/questions/23103174/does-okhttp-support-accepting-self-signed-ssl-certs
-      sslContext = SSLContext.getInstance("SSL");
-      TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-      trustManagerFactory.init(keyStore);
-      KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-      keyManagerFactory.init(keyStore, keyStorePass.toCharArray());
-      sslContext.init(keyManagerFactory.getKeyManagers(),trustManagerFactory.getTrustManagers(), new SecureRandom());
-      okBuilder.sslSocketFactory(sslContext.getSocketFactory(), (X509TrustManager) trustManagerFactory.getTrustManagers()[0]);
-    } catch (GeneralSecurityException e) {
-      throw new RuntimeException("Error while configuring SSL Certificates", e);
-    }
   }
 
   public IDVCApi initialize() {

--- a/src/main/java/com/devcycle/sdk/server/cloud/api/DVCCloudApiClient.java
+++ b/src/main/java/com/devcycle/sdk/server/cloud/api/DVCCloudApiClient.java
@@ -2,7 +2,9 @@ package com.devcycle.sdk.server.cloud.api;
 
 import com.devcycle.sdk.server.cloud.model.DVCCloudOptions;
 import com.devcycle.sdk.server.common.api.IDVCApi;
+import com.devcycle.sdk.server.common.exception.DVCException;
 import com.devcycle.sdk.server.common.interceptor.AuthorizationHeaderInterceptor;
+import com.devcycle.sdk.server.common.model.HttpResponseCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -10,6 +12,11 @@ import okhttp3.*;
 import retrofit2.Retrofit;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import java.security.*;
 import java.util.Objects;
 
 public final class DVCCloudApiClient {
@@ -42,6 +49,22 @@ public final class DVCCloudApiClient {
   public DVCCloudApiClient(String apiKey, DVCCloudOptions options) {
     this(options);
     okBuilder.addInterceptor(new AuthorizationHeaderInterceptor(apiKey));
+
+    KeyStore keyStore = null;//options.getCustomeCerts(); //todo Load from options
+    String keyStorePass = "keystore_pass"; //todo Load from options
+    SSLContext sslContext = null;
+    try {
+      // example code pulled from: https://stackoverflow.com/questions/23103174/does-okhttp-support-accepting-self-signed-ssl-certs
+      sslContext = SSLContext.getInstance("SSL");
+      TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+      trustManagerFactory.init(keyStore);
+      KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+      keyManagerFactory.init(keyStore, keyStorePass.toCharArray());
+      sslContext.init(keyManagerFactory.getKeyManagers(),trustManagerFactory.getTrustManagers(), new SecureRandom());
+      okBuilder.sslSocketFactory(sslContext.getSocketFactory(), (X509TrustManager) trustManagerFactory.getTrustManagers()[0]);
+    } catch (GeneralSecurityException e) {
+      throw new RuntimeException("Error while configuring SSL Certificates", e);
+    }
   }
 
   public IDVCApi initialize() {

--- a/src/main/java/com/devcycle/sdk/server/cloud/model/DVCCloudOptions.java
+++ b/src/main/java/com/devcycle/sdk/server/cloud/model/DVCCloudOptions.java
@@ -1,5 +1,6 @@
 package com.devcycle.sdk.server.cloud.model;
 
+import com.devcycle.sdk.server.common.api.IRestOptions;
 import com.devcycle.sdk.server.common.logging.IDVCLogger;
 import com.devcycle.sdk.server.common.model.IDVCOptions;
 
@@ -17,6 +18,9 @@ public class DVCCloudOptions {
 
     @Builder.Default
     private IDVCLogger customLogger = null;
+
+    @Builder.Default
+    private IRestOptions restOptions = null;
 
     public static class DVCCloudOptionsBuilder implements IDVCOptions { }
 }

--- a/src/main/java/com/devcycle/sdk/server/common/api/APIUtils.java
+++ b/src/main/java/com/devcycle/sdk/server/common/api/APIUtils.java
@@ -1,0 +1,21 @@
+package com.devcycle.sdk.server.common.api;
+
+import com.devcycle.sdk.server.common.interceptor.CustomHeaderInterceptor;
+import okhttp3.OkHttpClient;
+
+public class APIUtils {
+    public static void applyRestOptions(IRestOptions restOptions, OkHttpClient.Builder builder)
+    {
+        if(restOptions != null)
+        {
+            if(restOptions.getHostnameVerifier() != null){
+                builder.hostnameVerifier(restOptions.getHostnameVerifier());
+            }
+
+            if(restOptions.getSocketFactory() != null && restOptions.getTrustManager() != null){
+                builder.sslSocketFactory(restOptions.getSocketFactory(), restOptions.getTrustManager());
+            }
+            builder.addInterceptor(new CustomHeaderInterceptor(restOptions));
+        }
+    }
+}

--- a/src/main/java/com/devcycle/sdk/server/common/api/IRestOptions.java
+++ b/src/main/java/com/devcycle/sdk/server/common/api/IRestOptions.java
@@ -11,24 +11,23 @@ import java.util.Map;
  */
 public interface IRestOptions {
     /**
-     * @return A set of HTTP request headers that should be incorporated into all outgoing requests. A null map and
-     * null values will be ignored.
+     * @return A set of HTTP request headers that should be incorporated into all outgoing requests. return null if no headers are needed.
      */
     Map<String,String> getHeaders();
 
     /**
-     * @return Optional. A custom SSLSocketFactory to use when making requests. Return null if the default SSLSocket factory can be used
+     * @return A custom SSLSocketFactory to use when making requests. Return null if the default SSLSocket factory can be used
      */
     SSLSocketFactory getSocketFactory();
 
     /**
      *
-     * @return Optional. Provide a trust manager to handle custom certificates. Return null if the default trust manager can be used
+     * @return Provide a trust manager to handle custom certificates. Return null if the default trust manager can be used
      */
     X509TrustManager getTrustManager();
 
     /**
-     * @return Optional. A custom HostnameVerifier to use when making requests. Return null if the default HostnameVerifier can be used
+     * @return A custom HostnameVerifier to use when making requests. Return null if the default HostnameVerifier can be used
      */
     HostnameVerifier getHostnameVerifier();
 }

--- a/src/main/java/com/devcycle/sdk/server/common/api/IRestOptions.java
+++ b/src/main/java/com/devcycle/sdk/server/common/api/IRestOptions.java
@@ -1,13 +1,34 @@
 package com.devcycle.sdk.server.common.api;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509TrustManager;
 import java.util.Map;
 
+/**
+ * An interface for customizing how the DevCycle SDK makes external requests, allowing for the
+ * injection of custom headers or SSL configuration.
+ */
 public interface IRestOptions {
+    /**
+     * @return A set of HTTP request headers that should be incorporated into all outgoing requests. A null map and
+     * null values will be ignored.
+     */
     Map<String,String> getHeaders();
 
+    /**
+     * @return Optional. A custom SSLSocketFactory to use when making requests. Return null if the default SSLSocket factory can be used
+     */
     SSLSocketFactory getSocketFactory();
 
+    /**
+     *
+     * @return Optional. Provide a trust manager to handle custom certificates. Return null if the default trust manager can be used
+     */
     X509TrustManager getTrustManager();
+
+    /**
+     * @return Optional. A custom HostnameVerifier to use when making requests. Return null if the default HostnameVerifier can be used
+     */
+    HostnameVerifier getHostnameVerifier();
 }

--- a/src/main/java/com/devcycle/sdk/server/common/api/IRestOptions.java
+++ b/src/main/java/com/devcycle/sdk/server/common/api/IRestOptions.java
@@ -1,0 +1,13 @@
+package com.devcycle.sdk.server.common.api;
+
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
+import java.util.Map;
+
+public interface IRestOptions {
+    Map<String,String> getHeaders();
+
+    SSLSocketFactory getSocketFactory();
+
+    X509TrustManager getTrustManager();
+}

--- a/src/main/java/com/devcycle/sdk/server/common/interceptor/CustomHeaderInterceptor.java
+++ b/src/main/java/com/devcycle/sdk/server/common/interceptor/CustomHeaderInterceptor.java
@@ -1,0 +1,39 @@
+package com.devcycle.sdk.server.common.interceptor;
+
+import com.devcycle.sdk.server.common.api.IRestOptions;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Interceptor to inject custom headers into all requests based on an IRestOptions
+ * implementation
+ */
+public final class CustomHeaderInterceptor implements Interceptor {
+    private IRestOptions restOptions;
+
+    public CustomHeaderInterceptor(IRestOptions restOptions) {
+        this.restOptions = restOptions;
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request request = chain.request();
+
+        if(restOptions != null) {
+            Request.Builder builder = request.newBuilder();
+
+            for (Map.Entry<String, String> entry : restOptions.getHeaders().entrySet()) {
+                if(entry.getValue() != null) {
+                    builder.addHeader(entry.getKey(), entry.getValue());
+                }
+            }
+
+            request = builder.build();
+        }
+        return chain.proceed(request);
+    }
+}

--- a/src/main/java/com/devcycle/sdk/server/local/api/DVCLocalApiClient.java
+++ b/src/main/java/com/devcycle/sdk/server/local/api/DVCLocalApiClient.java
@@ -1,6 +1,8 @@
 package com.devcycle.sdk.server.local.api;
 
 import com.devcycle.sdk.server.common.api.IDVCApi;
+import com.devcycle.sdk.server.common.api.IRestOptions;
+import com.devcycle.sdk.server.common.interceptor.CustomHeaderInterceptor;
 import com.devcycle.sdk.server.local.model.DVCLocalOptions;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -30,6 +32,19 @@ public final class DVCLocalApiClient {
 
     OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     okBuilder = new OkHttpClient.Builder();
+
+    IRestOptions restOptions = options.getRestOptions();
+    if(restOptions != null)
+    {
+      if(restOptions.getHostnameVerifier() != null){
+        okBuilder.hostnameVerifier(restOptions.getHostnameVerifier());
+      }
+
+      if(restOptions.getSocketFactory() != null && restOptions.getTrustManager() != null){
+        okBuilder.sslSocketFactory(restOptions.getSocketFactory(), restOptions.getTrustManager());
+      }
+      okBuilder.addInterceptor(new CustomHeaderInterceptor(restOptions));
+    }
 
     String cdnUrlFromOptions = options.getConfigCdnBaseUrl();
     int configRequestTimeoutMs = options.getConfigRequestTimeoutMs();

--- a/src/main/java/com/devcycle/sdk/server/local/api/DVCLocalApiClient.java
+++ b/src/main/java/com/devcycle/sdk/server/local/api/DVCLocalApiClient.java
@@ -1,5 +1,6 @@
 package com.devcycle.sdk.server.local.api;
 
+import com.devcycle.sdk.server.common.api.APIUtils;
 import com.devcycle.sdk.server.common.api.IDVCApi;
 import com.devcycle.sdk.server.common.api.IRestOptions;
 import com.devcycle.sdk.server.common.interceptor.CustomHeaderInterceptor;
@@ -33,18 +34,7 @@ public final class DVCLocalApiClient {
     OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     okBuilder = new OkHttpClient.Builder();
 
-    IRestOptions restOptions = options.getRestOptions();
-    if(restOptions != null)
-    {
-      if(restOptions.getHostnameVerifier() != null){
-        okBuilder.hostnameVerifier(restOptions.getHostnameVerifier());
-      }
-
-      if(restOptions.getSocketFactory() != null && restOptions.getTrustManager() != null){
-        okBuilder.sslSocketFactory(restOptions.getSocketFactory(), restOptions.getTrustManager());
-      }
-      okBuilder.addInterceptor(new CustomHeaderInterceptor(restOptions));
-    }
+    APIUtils.applyRestOptions(options.getRestOptions(), okBuilder);
 
     String cdnUrlFromOptions = options.getConfigCdnBaseUrl();
     int configRequestTimeoutMs = options.getConfigRequestTimeoutMs();

--- a/src/main/java/com/devcycle/sdk/server/local/api/DVCLocalEventsApiClient.java
+++ b/src/main/java/com/devcycle/sdk/server/local/api/DVCLocalEventsApiClient.java
@@ -1,5 +1,6 @@
 package com.devcycle.sdk.server.local.api;
 
+import com.devcycle.sdk.server.common.api.APIUtils;
 import com.devcycle.sdk.server.common.api.IDVCApi;
 import com.devcycle.sdk.server.common.api.IRestOptions;
 import com.devcycle.sdk.server.common.interceptor.AuthorizationHeaderInterceptor;
@@ -29,18 +30,7 @@ public final class DVCLocalEventsApiClient {
         OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         okBuilder = new OkHttpClient.Builder();
 
-        IRestOptions restOptions = options.getRestOptions();
-        if(restOptions != null)
-        {
-            if(restOptions.getHostnameVerifier() != null){
-                okBuilder.hostnameVerifier(restOptions.getHostnameVerifier());
-            }
-
-            if(restOptions.getSocketFactory() != null && restOptions.getTrustManager() != null){
-                okBuilder.sslSocketFactory(restOptions.getSocketFactory(), restOptions.getTrustManager());
-            }
-            okBuilder.addInterceptor(new CustomHeaderInterceptor(restOptions));
-        }
+        APIUtils.applyRestOptions(options.getRestOptions(), okBuilder);
 
         okBuilder.addInterceptor(new AuthorizationHeaderInterceptor(sdkKey));
 

--- a/src/main/java/com/devcycle/sdk/server/local/model/DVCLocalOptions.java
+++ b/src/main/java/com/devcycle/sdk/server/local/model/DVCLocalOptions.java
@@ -1,5 +1,6 @@
 package com.devcycle.sdk.server.local.model;
 
+import com.devcycle.sdk.server.common.api.IRestOptions;
 import com.devcycle.sdk.server.common.model.IDVCOptions;
 import com.devcycle.sdk.server.common.logging.DVCLogger;
 import com.devcycle.sdk.server.common.logging.IDVCLogger;
@@ -42,6 +43,9 @@ public class DVCLocalOptions implements IDVCOptions {
 
     private boolean disableCustomEventLogging = false;
 
+    @JsonIgnore
+    private IRestOptions restOptions = null;
+
     @Builder()
     public DVCLocalOptions(
             int configRequestTimeoutMs,
@@ -56,7 +60,8 @@ public class DVCLocalOptions implements IDVCOptions {
             int eventRequestChunkSize,
             boolean disableAutomaticEventLogging,
             boolean disableCustomEventLogging,
-            IDVCLogger customLogger
+            IDVCLogger customLogger,
+            IRestOptions restOptions
     ) {
         this.configRequestTimeoutMs = configRequestTimeoutMs > 0 ? configRequestTimeoutMs : this.configRequestTimeoutMs;
         this.configPollingIntervalMS = getConfigPollingIntervalMS(configPollingIntervalMs, configPollingIntervalMS);
@@ -69,6 +74,7 @@ public class DVCLocalOptions implements IDVCOptions {
         this.disableAutomaticEventLogging = disableAutomaticEventLogging;
         this.disableCustomEventLogging = disableCustomEventLogging;
         this.customLogger = customLogger;
+        this.restOptions = restOptions;
 
         if (this.flushEventQueueSize >= this.maxEventQueueSize) {
             DVCLogger.warning("flushEventQueueSize: " + this.flushEventQueueSize + " must be smaller than maxEventQueueSize: " + this.maxEventQueueSize);

--- a/src/test/java/com/devcycle/sdk/server/local/DVCLocalClientTest.java
+++ b/src/test/java/com/devcycle/sdk/server/local/DVCLocalClientTest.java
@@ -80,7 +80,7 @@ public class DVCLocalClientTest {
 
         @Override
         public HostnameVerifier getHostnameVerifier() {
-            return (hostname, session) -> true;
+            return null;
         }
     };
 

--- a/src/test/java/com/devcycle/sdk/server/local/DVCLocalClientTest.java
+++ b/src/test/java/com/devcycle/sdk/server/local/DVCLocalClientTest.java
@@ -1,5 +1,6 @@
 package com.devcycle.sdk.server.local;
 
+import com.devcycle.sdk.server.common.api.IRestOptions;
 import com.devcycle.sdk.server.common.logging.IDVCLogger;
 import com.devcycle.sdk.server.common.model.BaseVariable;
 import com.devcycle.sdk.server.common.model.Feature;
@@ -16,6 +17,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -53,6 +58,32 @@ public class DVCLocalClientTest {
         }
     };
 
+    static IRestOptions restOptions = new IRestOptions() {
+
+        @Override
+        public Map<String, String> getHeaders() {
+            Map<String,String> headers = new HashMap<>();
+            headers.put("Oauth-Token", "test-token");
+            headers.put("Custom-Meta-Data", "some information the developer wants send");
+            return headers;
+        }
+
+        @Override
+        public SSLSocketFactory getSocketFactory() {
+            return null;
+        }
+
+        @Override
+        public X509TrustManager getTrustManager() {
+            return null;
+        }
+
+        @Override
+        public HostnameVerifier getHostnameVerifier() {
+            return (hostname, session) -> true;
+        }
+    };
+
     @BeforeClass
     public static void setup() throws Exception {
         // spin up a lightweight http server to serve the config and properly initialize the client
@@ -68,6 +99,7 @@ public class DVCLocalClientTest {
                 .configCdnBaseUrl("http://localhost:8000/")
                 .configPollingIntervalMS(60000)
                 .customLogger(testLoggingWrapper)
+                .restOptions(restOptions)
                 .build();
 
         DVCLocalClient client = new DVCLocalClient(apiKey, options);

--- a/src/test/java/com/devcycle/sdk/server/utils/ByteConversionUtilsTest.java
+++ b/src/test/java/com/devcycle/sdk/server/utils/ByteConversionUtilsTest.java
@@ -31,8 +31,6 @@ public class ByteConversionUtilsTest {
         int expected = 123456789;
 
         int result = ByteConversionUtils.bytesToIntLittleEndian(encodedValue);
-        System.out.println(Integer.toHexString(expected));
-        System.out.println(Integer.toHexString(result));
         Assert.assertEquals(expected, result);
     }
 }


### PR DESCRIPTION
Added interface that can be implemented to inject custom headers and SSL configuration into API calls for the local and cloud client. 

Developers can implement the IRestOptions interface and supply it with the options object for either the cloud or local bucketing client. When supplied, this object will be used to setup the OKHttpClient used internally to add custom headers and cert information.

Code paths are fully optional so this new feature will be safe to merge without negatively impacting existing SDK users.
