### PR TITLE
[fix] Prevent multiple authorization headers in Events API requests

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -1,34 +1,3 @@
-<!--
-Copyright (c) 2014, Oracle America, Inc.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
- * Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
-
- * Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-
- * Neither the name of Oracle nor the names of its contributors may be used
-   to endorse or promote products derived from this software without
-   specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-THE POSSIBILITY OF SUCH DAMAGE.
--->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/src/main/java/com/devcycle/sdk/server/common/interceptor/AuthorizationHeaderInterceptor.java
+++ b/src/main/java/com/devcycle/sdk/server/common/interceptor/AuthorizationHeaderInterceptor.java
@@ -20,8 +20,16 @@ public final class AuthorizationHeaderInterceptor implements Interceptor {
     public Response intercept(Chain chain) throws IOException {
         Request request = chain.request();
 
+        String headerName = AUTHORIZATION_HEADER;
+
+        // Is there already an authorization header on the request?
+        // If so, we need to rename ours to avoid conflicts
+        if(request.header(AUTHORIZATION_HEADER) != null) {
+            headerName = "DevCycle-" + AUTHORIZATION_HEADER;
+        }
+
         request = request.newBuilder()
-                .addHeader(AUTHORIZATION_HEADER, apiKey)
+                .addHeader(headerName, apiKey)
                 .build();
 
         return chain.proceed(request);


### PR DESCRIPTION
RBC noticed that if they use the new IRestOptions interface to inject headers and then add their own Authorization header with an APIGEE token, the SDK will still add our own Authorization header with SDK key for Event API requests.  

Including two headers with the same name goes against RFC 7230/7235 and will be rejected by some servers.  

They need to set their own Authorization header and then have the DevCycle key provided in a different, known header which they can rewrite at the proxy level. To mitigate this the code detects the scenario and rename `Authorization` to `DevCycle-Authorization`, with the assumption the developer will use some kind of rewrite rule in their proxy before making the call to the DevCycle Events API