### PR TITLE
chore: Update wasmtime-java and tweak logs (DVC 8452)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This version of the DevCycle SDK works with Java 8 and above.
 
 Using the Java SDK library requires [Maven](https://maven.apache.org/) or [Gradle](https://gradle.org/) >= 7.6+ to be installed.
 
-An x86_64 JDK is required for Local Bucketing with the DevCycle Java SDK. 
+An x86_64 or aarch64 JDK is required for Local Bucketing with the DevCycle Java SDK.
 
 Currently Supported Platforms are:
 
@@ -16,9 +16,10 @@ Currently Supported Platforms are:
 | --- | --- |
 | Linux (ELF) | x86_64 |
 | Mac OS | x86_64 |
+| Mac OS | aarch64 |
 | Windows | x86_64 |
 
-In addition, the environment must support GLIBC v2.32 or higher.  You can use the following command to check your GLIBC version:
+In addition, the environment must support GLIBC v2.16 or higher.  You can use the following command to check your GLIBC version:
 
 ```bash
 ldd --version

--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ ext {
     swagger_annotations_version = "2.2.0"
     lombok_version = "1.18.24"
     okhttp_version = "4.9.3"
-    wasmtime_version = "0.15.0"
+    wasmtime_version = "0.17.0"
     junit_version = "4.13.2"
     mockito_core_version = "4.6.1"
     protobuf_version = "3.23.0"

--- a/src/main/java/com/devcycle/sdk/server/local/api/DVCLocalClient.java
+++ b/src/main/java/com/devcycle/sdk/server/local/api/DVCLocalClient.java
@@ -45,7 +45,7 @@ public final class DVCLocalClient {
     }
 
     if(!isValidRuntime()){
-      DVCLogger.warning("Invalid architecture. The DVCLocalClient requires a 64-bit, x86 runtime environment.");
+      DVCLogger.warning("The DVCLocalClient requires a 64-bit, x86 or aarch64 runtime environment. This architecture may not be supported: " + System.getProperty("os.arch") + " | " + System.getProperty("sun.arch.data.model"));
     }
 
     localBucketing.setPlatformData(PlatformData.builder().build().toString());
@@ -260,8 +260,19 @@ public final class DVCLocalClient {
   }
 
   private boolean isValidRuntime() {
-    String arch = System.getProperty("os.arch");
-    String model = System.getProperty("sun.arch.data.model");
-    return arch.contains("x86") && model.contains("64");
+    String os = System.getProperty("os.name").toLowerCase();
+    String arch = System.getProperty("os.arch").toLowerCase();
+    String model = System.getProperty("sun.arch.data.model").toLowerCase();
+    if (arch.contains("x86") && model.contains("64")) {
+      // Assume support for all x86_64 platforms
+      return true;
+    }
+    if (os.contains("mac os") || os.contains("darwin")) {
+      if (arch.equals("aarch64")) {
+        // Specific case of Apple Silicon
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/main/java/com/devcycle/sdk/server/local/api/DVCLocalClient.java
+++ b/src/main/java/com/devcycle/sdk/server/local/api/DVCLocalClient.java
@@ -55,7 +55,7 @@ public final class DVCLocalClient {
     try {
       eventQueueManager = new EventQueueManager(sdkKey, localBucketing, dvcOptions);
     } catch (Exception e) {
-      DVCLogger.warning("Error creating event queue due to error: " + e.getMessage());
+      DVCLogger.error("Error creating event queue due to error: " + e.getMessage());
     }
   }
 
@@ -85,7 +85,7 @@ public final class DVCLocalClient {
     try {
       bucketedUserConfig = localBucketing.generateBucketedConfig(sdkKey, user);
     } catch (JsonProcessingException e) {
-      DVCLogger.info("Unable to parse JSON for allFeatures due to error: " + e.getMessage());
+      DVCLogger.error("Unable to parse JSON for allFeatures due to error: " + e.getMessage());
       return Collections.emptyMap();
     }
     return bucketedUserConfig.features;
@@ -161,7 +161,7 @@ public final class DVCLocalClient {
       } else {
         SDKVariable_PB sdkVariable = SDKVariable_PB.parseFrom(variableData);
         if(sdkVariable.getType() != pbVariableType) {
-          DVCLogger.info("Variable type mismatch, returning default value");
+          DVCLogger.warning("Variable type mismatch, returning default value");
           return defaultVariable;
         }
         return ProtobufUtils.createVariable(sdkVariable, defaultValue);
@@ -189,7 +189,7 @@ public final class DVCLocalClient {
     try {
       bucketedUserConfig = localBucketing.generateBucketedConfig(sdkKey, user);
     } catch (JsonProcessingException e) {
-      DVCLogger.info("Unable to parse JSON for allVariables due to error: " + e.getMessage());
+      DVCLogger.error("Unable to parse JSON for allVariables due to error: " + e.getMessage());
       return Collections.emptyMap();
     }
     return bucketedUserConfig.variables;
@@ -211,14 +211,14 @@ public final class DVCLocalClient {
     try {
       eventQueueManager.queueEvent(user, event);
     } catch (Exception e) {
-      DVCLogger.warning("Failed to queue event due to error: " + e.getMessage());
+      DVCLogger.error("Failed to queue event due to error: " + e.getMessage());
     }
   }
 
   public void setClientCustomData(Map<String,Object> customData) {
     if (!isInitialized())
     {
-      DVCLogger.info("SetClientCustomData called before DVCClient has initialized");
+      DVCLogger.error("SetClientCustomData called before DVCClient has initialized");
      return;
     }
 

--- a/src/main/java/com/devcycle/sdk/server/local/managers/EnvironmentConfigManager.java
+++ b/src/main/java/com/devcycle/sdk/server/local/managers/EnvironmentConfigManager.java
@@ -57,7 +57,7 @@ public final class EnvironmentConfigManager {
             getConfig();
           }
         } catch (DVCException e) {
-          DVCLogger.info("Failed to load config: " + e.getMessage());
+          DVCLogger.error("Failed to load config: " + e.getMessage());
         }
       }
     };
@@ -136,7 +136,7 @@ public final class EnvironmentConfigManager {
         localBucketing.storeConfig(sdkKey, mapper.writeValueAsString(config));
       } catch (JsonProcessingException e) {
         if (this.config != null) {
-          DVCLogger.debug("Unable to parse config with etag: " + currentETag + ". Using cache, etag " + this.configETag);
+          DVCLogger.error("Unable to parse config with etag: " + currentETag + ". Using cache, etag " + this.configETag);
           return this.config;
         } else {
           errorResponse.setMessage(e.getMessage());

--- a/src/main/java/com/devcycle/sdk/server/local/managers/EventQueueManager.java
+++ b/src/main/java/com/devcycle/sdk/server/local/managers/EventQueueManager.java
@@ -76,7 +76,7 @@ public class EventQueueManager {
 
         if (flushPayloads.length == 0) return;
 
-        DVCLogger.info("DVC Flush Payloads: " + Arrays.toString(flushPayloads));
+        DVCLogger.debug("DVC Flush Payloads: " + Arrays.toString(flushPayloads));
 
         int eventCount = 0;
         isFlushingEvents = true;
@@ -85,7 +85,7 @@ public class EventQueueManager {
             publishEvents(this.sdkKey, payload);
         }
         isFlushingEvents = false;
-        DVCLogger.info(String.format("DVC Flush %d AS Events, for %d Users", eventCount, flushPayloads.length));
+        DVCLogger.debug(String.format("DVC Flush %d AS Events, for %d Users", eventCount, flushPayloads.length));
     }
 
     /**


### PR DESCRIPTION
This updates wasmtime-java to v0.17.0 and updates the log level for an error log that was too low to see if the INFO level was filtered out.

I also updated a few other logs that seemed to be at the wrong level - I'm open to changing them back though.