### PR TITLE
fix: the build that was broken by the automated release commit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ java {
 
 group = "com.devcycle"
 archivesBaseName = "java-server-sdk"
-version = "2.1.1"
+version = "2.1.0"
 
 publishing {
     publications {


### PR DESCRIPTION
Doing this so that the release action will create a commit that actually has changes made when updating from 2.1.0 to 2.1.1