### PR TITLE
feat: set SSE connections as the default

### DIFF
--- a/src/main/java/com/devcycle/sdk/server/local/managers/EnvironmentConfigManager.java
+++ b/src/main/java/com/devcycle/sdk/server/local/managers/EnvironmentConfigManager.java
@@ -83,7 +83,7 @@ public final class EnvironmentConfigManager {
     private ProjectConfig getConfig() throws DevCycleException {
         Call<ProjectConfig> config = this.configApiClient.getConfig(this.sdkKey, this.configETag, this.configLastModified);
         this.config = getResponseWithRetries(config, 1);
-        if (this.options.isEnableBetaRealtimeUpdates()) {
+        if (!this.options.isDisableRealtimeUpdates()) {
             try {
                 URI uri = new URI(this.config.getSse().getHostname() + this.config.getSse().getPath());
                 if (sseManager == null) {

--- a/src/main/java/com/devcycle/sdk/server/local/model/DevCycleLocalOptions.java
+++ b/src/main/java/com/devcycle/sdk/server/local/model/DevCycleLocalOptions.java
@@ -28,6 +28,12 @@ public class DevCycleLocalOptions implements IDevCycleOptions {
 
     private boolean disableAutomaticEventLogging = false;
 
+    private boolean disableRealtimeUpdates = false;
+
+    /**
+     * @deprecated real time updates are enabled by default now
+     */
+    @Deprecated
     private boolean enableBetaRealtimeUpdates = false;
 
     @JsonIgnore
@@ -52,7 +58,9 @@ public class DevCycleLocalOptions implements IDevCycleOptions {
             boolean disableCustomEventLogging,
             IDevCycleLogger customLogger,
             IRestOptions restOptions,
-            boolean enableBetaRealtimeUpdates
+            @Deprecated 
+            boolean enableBetaRealtimeUpdates,
+            boolean disableRealtimeUpdates
     ) {
         this.configRequestTimeoutMs = configRequestTimeoutMs > 0 ? configRequestTimeoutMs : this.configRequestTimeoutMs;
         this.configPollingIntervalMS = getConfigPollingIntervalMS(configPollingIntervalMs, configPollingIntervalMS);
@@ -67,6 +75,7 @@ public class DevCycleLocalOptions implements IDevCycleOptions {
         this.customLogger = customLogger;
         this.restOptions = restOptions;
         this.enableBetaRealtimeUpdates = enableBetaRealtimeUpdates;
+        this.disableRealtimeUpdates = disableRealtimeUpdates;
 
         if (this.flushEventQueueSize >= this.maxEventQueueSize) {
             DevCycleLogger.warning("flushEventQueueSize: " + this.flushEventQueueSize + " must be smaller than maxEventQueueSize: " + this.maxEventQueueSize);


### PR DESCRIPTION
Depricate `enableBetaRealtimeUpdates` and add new `disableRealtimeUpdates` option. SSE connections are now enabled by default and will fall back to polling against the config CDN.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
