### PR TITLE
chore: Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/java-server-sdk/security/code-scanning/5](https://github.com/DevCycleHQ/java-server-sdk/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs read operations (e.g., checking out the code and running tests), we will set `contents: read` as the minimal required permission. This ensures the workflow has the least privileges necessary to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
