### PR TITLE
feat: add config metadata

### DIFF
--- a/src/examples/java/com/devcycle/examples/LocalExample.java
+++ b/src/examples/java/com/devcycle/examples/LocalExample.java
@@ -40,8 +40,8 @@ public class LocalExample {
             @Override
             public Optional<HookContext<String>> before(HookContext<String> ctx) {
                 System.out.println("before");
-                System.out.println(ctx.getMetadata().project.key);
-                System.out.println(ctx.getMetadata().environment.key);
+                System.out.println(ctx.getMetadata().getProject().getKey());
+                System.out.println(ctx.getMetadata().getEnvironment().getKey());
                 return Optional.of(ctx);
             }
 
@@ -49,15 +49,15 @@ public class LocalExample {
             public void after(HookContext<String> ctx, Variable<String> variable) {
                 System.out.println("after");
                 System.out.println(variable.getValue());
-                System.out.println(ctx.getMetadata().project.key);
-                System.out.println(ctx.getMetadata().environment.key);
+                System.out.println(ctx.getMetadata().getProject().getKey());
+                System.out.println(ctx.getMetadata().getEnvironment().getKey());
             }
 
             @Override
             public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
                 System.out.println("finally");
-                System.out.println(ctx.getMetadata().project.key);
-                System.out.println(ctx.getMetadata().environment.key);
+                System.out.println(ctx.getMetadata().getProject().getKey());
+                System.out.println(ctx.getMetadata().getEnvironment().getKey());
             }
         });
 

--- a/src/examples/java/com/devcycle/examples/LocalExample.java
+++ b/src/examples/java/com/devcycle/examples/LocalExample.java
@@ -1,18 +1,13 @@
 package com.devcycle.examples;
 
-import java.util.Optional;
-
 import com.devcycle.sdk.server.common.logging.SimpleDevCycleLogger;
 import com.devcycle.sdk.server.common.model.DevCycleEvent;
 import com.devcycle.sdk.server.common.model.DevCycleUser;
-import com.devcycle.sdk.server.common.model.EvalHook;
-import com.devcycle.sdk.server.common.model.HookContext;
-import com.devcycle.sdk.server.common.model.Variable;
 import com.devcycle.sdk.server.local.api.DevCycleLocalClient;
 import com.devcycle.sdk.server.local.model.DevCycleLocalOptions;
 
 public class LocalExample {
-    public static String VARIABLE_KEY = "example-text";
+    public static String VARIABLE_KEY = "test-boolean-variable";
 
     public static void main(String[] args) throws InterruptedException {
         String server_sdk_key = System.getenv("DEVCYCLE_SERVER_SDK_KEY");
@@ -23,11 +18,11 @@ public class LocalExample {
 
         // Create user object
         DevCycleUser user = DevCycleUser.builder()
-                .userId("j_test")
+                .userId("SOME_USER_ID")
                 .build();
 
         // The default value can be of type string, boolean, number, or JSON
-        String defaultValue = "false";
+        Boolean defaultValue = false;
 
         DevCycleLocalOptions options = DevCycleLocalOptions.builder()
                 .customLogger(new SimpleDevCycleLogger(SimpleDevCycleLogger.Level.DEBUG))
@@ -35,31 +30,6 @@ public class LocalExample {
 
         // Initialize DevCycle Client
         DevCycleLocalClient client = new DevCycleLocalClient(server_sdk_key, options);
-
-        client.addHook(new EvalHook<String>() {
-            @Override
-            public Optional<HookContext<String>> before(HookContext<String> ctx) {
-                System.out.println("before");
-                System.out.println(ctx.getMetadata().getProject().getKey());
-                System.out.println(ctx.getMetadata().getEnvironment().getKey());
-                return Optional.of(ctx);
-            }
-
-            @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
-                System.out.println("after");
-                System.out.println(variable.getValue());
-                System.out.println(ctx.getMetadata().getProject().getKey());
-                System.out.println(ctx.getMetadata().getEnvironment().getKey());
-            }
-
-            @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
-                System.out.println("finally");
-                System.out.println(ctx.getMetadata().getProject().getKey());
-                System.out.println(ctx.getMetadata().getEnvironment().getKey());
-            }
-        });
 
         for (int i = 0; i < 10; i++) {
             if (client.isInitialized()) {
@@ -71,13 +41,13 @@ public class LocalExample {
         // Fetch variable values using the identifier key, with a default value and user
         // object
         // The default value can be of type string, boolean, number, or JSON
-        String variableValue = client.variableValue(user, VARIABLE_KEY, defaultValue);
+        Boolean variableValue = client.variableValue(user, VARIABLE_KEY, defaultValue);
 
         // Use variable value
-        if (variableValue.equals("true")) {
+        if (variableValue) {
             System.out.println("feature is enabled");
         } else {
-            System.out.println("feature is NOT enabled: " + variableValue);
+            System.out.println("feature is NOT enabled");
         }
 
         DevCycleEvent event = DevCycleEvent.builder().type("local-test").build();

--- a/src/main/java/com/devcycle/sdk/server/cloud/api/DevCycleCloudApiClient.java
+++ b/src/main/java/com/devcycle/sdk/server/cloud/api/DevCycleCloudApiClient.java
@@ -3,8 +3,8 @@ package com.devcycle.sdk.server.cloud.api;
 import com.devcycle.sdk.server.cloud.model.DevCycleCloudOptions;
 import com.devcycle.sdk.server.common.api.APIUtils;
 import com.devcycle.sdk.server.common.api.IDevCycleApi;
+import com.devcycle.sdk.server.common.api.ObjectMapperUtils;
 import com.devcycle.sdk.server.common.interceptor.AuthorizationHeaderInterceptor;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
@@ -14,14 +14,13 @@ import java.util.Objects;
 
 public final class DevCycleCloudApiClient {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperUtils.createDefaultObjectMapper();
     private static final String BUCKETING_URL = "https://bucketing-api.devcycle.com/";
     private final OkHttpClient.Builder okBuilder;
     private final Retrofit.Builder adapterBuilder;
     private String bucketingUrl;
 
     public DevCycleCloudApiClient(String apiKey, DevCycleCloudOptions options) {
-        OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         okBuilder = new OkHttpClient.Builder();
 
         APIUtils.applyRestOptions(options.getRestOptions(), okBuilder);
@@ -38,7 +37,7 @@ public final class DevCycleCloudApiClient {
 
         adapterBuilder = new Retrofit.Builder()
                 .baseUrl(bucketingUrl)
-                .addConverterFactory(JacksonConverterFactory.create());
+                .addConverterFactory(JacksonConverterFactory.create(OBJECT_MAPPER));
     }
 
     public IDevCycleApi initialize() {

--- a/src/main/java/com/devcycle/sdk/server/cloud/api/DevCycleCloudClient.java
+++ b/src/main/java/com/devcycle/sdk/server/cloud/api/DevCycleCloudClient.java
@@ -3,6 +3,7 @@ package com.devcycle.sdk.server.cloud.api;
 import com.devcycle.sdk.server.cloud.model.DevCycleCloudOptions;
 import com.devcycle.sdk.server.common.api.IDevCycleApi;
 import com.devcycle.sdk.server.common.api.IDevCycleClient;
+import com.devcycle.sdk.server.common.api.ObjectMapperUtils;
 import com.devcycle.sdk.server.common.exception.AfterHookError;
 import com.devcycle.sdk.server.common.exception.BeforeHookError;
 import com.devcycle.sdk.server.common.exception.DevCycleException;
@@ -10,7 +11,6 @@ import com.devcycle.sdk.server.common.logging.DevCycleLogger;
 import com.devcycle.sdk.server.common.model.*;
 import com.devcycle.sdk.server.common.model.Variable.TypeEnum;
 import com.devcycle.sdk.server.openfeature.DevCycleProvider;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
@@ -23,7 +23,7 @@ import java.util.*;
 
 public final class DevCycleCloudClient implements IDevCycleClient {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperUtils.createDefaultObjectMapper();
     private final IDevCycleApi api;
     private final DevCycleCloudOptions dvcOptions;
     private final DevCycleProvider openFeatureProvider;
@@ -48,7 +48,6 @@ public final class DevCycleCloudClient implements IDevCycleClient {
 
         this.dvcOptions = options;
         api = new DevCycleCloudApiClient(sdkKey, options).initialize();
-        OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
         this.openFeatureProvider = new DevCycleProvider(this);
         this.evalHooksRunner = new EvalHooksRunner(dvcOptions.getHooks());
@@ -112,7 +111,7 @@ public final class DevCycleCloudClient implements IDevCycleClient {
 
         TypeEnum variableType = TypeEnum.fromClass(defaultValue.getClass());
         Variable<T> variable = null;
-        HookContext<T> context = new HookContext<T>(user, key, defaultValue);
+        HookContext<T> context = new HookContext<T>(user, key, defaultValue, null);
         ArrayList<EvalHook<T>> hooks = new ArrayList<EvalHook<T>>(evalHooksRunner.getHooks());
         ArrayList<EvalHook<T>> reversedHooks = new ArrayList<>(hooks);
         Collections.reverse(reversedHooks);

--- a/src/main/java/com/devcycle/sdk/server/common/api/ObjectMapperUtils.java
+++ b/src/main/java/com/devcycle/sdk/server/common/api/ObjectMapperUtils.java
@@ -1,0 +1,48 @@
+package com.devcycle.sdk.server.common.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ * Utility class for providing pre-configured ObjectMapper instances
+ * with consistent settings across the DevCycle SDK.
+ */
+public class ObjectMapperUtils {
+
+    /**
+     * Creates a new ObjectMapper with DevCycle SDK default configuration:
+     * - Ignores unknown properties during deserialization
+     * - Excludes null values from serialization
+     * - Uses consistent date/time formatting
+     * 
+     * @return A pre-configured ObjectMapper instance
+     */
+    public static ObjectMapper createDefaultObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        
+        // Ignore unknown properties to handle API changes gracefully
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        
+        // Don't include null values in JSON output
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        
+        return mapper;
+    }
+
+    /**
+     * Creates an ObjectMapper specifically configured for event processing
+     * with additional date formatting settings.
+     * 
+     * @return A pre-configured ObjectMapper for events
+     */
+    public static ObjectMapper createEventObjectMapper() {
+        ObjectMapper mapper = createDefaultObjectMapper();
+        
+        // Disable timestamp serialization for events
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        
+        return mapper;
+    }
+} 

--- a/src/main/java/com/devcycle/sdk/server/common/model/HookContext.java
+++ b/src/main/java/com/devcycle/sdk/server/common/model/HookContext.java
@@ -2,6 +2,8 @@ package com.devcycle.sdk.server.common.model;
 
 import java.util.Map;
 
+import com.devcycle.sdk.server.local.model.ConfigMetadata;
+
 /**
  * Context object passed to hooks during variable evaluation.
  * Contains the user, variable key, default value, and additional context data.
@@ -10,19 +12,22 @@ public class HookContext<T> {
     private DevCycleUser user;
     private final String key;
     private final T defaultValue;
+    private final ConfigMetadata metadata;
     private Variable<T> variableDetails;
 
-    public HookContext(DevCycleUser user, String key, T defaultValue) {
+    public HookContext(DevCycleUser user, String key, T defaultValue, ConfigMetadata metadata) {
         this.user = user;
         this.key = key;
         this.defaultValue = defaultValue;
+        this.metadata = metadata;
     }
 
-    public HookContext(DevCycleUser user, String key, T defaultValue, Variable<T> variable) {
+    public HookContext(DevCycleUser user, String key, T defaultValue, Variable<T> variable, ConfigMetadata metadata) {
         this.user = user;
         this.key = key;
         this.defaultValue = defaultValue;
         this.variableDetails = variable;
+        this.metadata = metadata;
     }
 
     public DevCycleUser getUser() {
@@ -39,10 +44,14 @@ public class HookContext<T> {
 
     public Variable<T> getVariableDetails() { return variableDetails; }
 
+    public ConfigMetadata getMetadata() {
+        return metadata;
+    }
+
     public HookContext<T> merge(HookContext<T> other) {
         if (other == null) {
             return this;
         }
-        return new HookContext<>(other.getUser(), key, defaultValue, variableDetails);
+        return new HookContext<>(other.getUser(), key, defaultValue, variableDetails, metadata);
     }
 }

--- a/src/main/java/com/devcycle/sdk/server/common/model/ProjectConfig.java
+++ b/src/main/java/com/devcycle/sdk/server/common/model/ProjectConfig.java
@@ -1,6 +1,9 @@
 package com.devcycle.sdk.server.common.model;
 
+import com.devcycle.sdk.server.local.model.Environment;
+import com.devcycle.sdk.server.local.model.Project;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,10 +18,12 @@ import lombok.NoArgsConstructor;
 public class ProjectConfig {
 
     @Schema(description = "Project Settings")
-    private Object project;
+    @JsonProperty("project")
+    private Project project;
 
     @Schema(description = "Environment Key & ID")
-    private Object environment;
+    @JsonProperty("environment")
+    private Environment environment;
 
     @Schema(description = "List of Features in this Project")
     private Object[] features;
@@ -34,5 +39,13 @@ public class ProjectConfig {
 
     @Schema(description = "SSE Configuration")
     private SSE sse;
+
+    public Project getProject() {
+        return project;
+    }
+
+    public Environment getEnvironment() {
+        return environment;
+    }
 }
 

--- a/src/main/java/com/devcycle/sdk/server/local/api/DevCycleLocalApiClient.java
+++ b/src/main/java/com/devcycle/sdk/server/local/api/DevCycleLocalApiClient.java
@@ -2,8 +2,8 @@ package com.devcycle.sdk.server.local.api;
 
 import com.devcycle.sdk.server.common.api.APIUtils;
 import com.devcycle.sdk.server.common.api.IDevCycleApi;
+import com.devcycle.sdk.server.common.api.ObjectMapperUtils;
 import com.devcycle.sdk.server.local.model.DevCycleLocalOptions;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 
 public final class DevCycleLocalApiClient {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperUtils.createDefaultObjectMapper();
     private static final String CONFIG_URL = "https://config-cdn.devcycle.com/";
     private static final int DEFAULT_TIMEOUT_MS = 10000;
     private static final int MIN_INTERVALS_MS = 1000;
@@ -25,7 +25,6 @@ public final class DevCycleLocalApiClient {
 
     private DevCycleLocalApiClient(DevCycleLocalOptions options) {
 
-        OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         okBuilder = new OkHttpClient.Builder();
 
         APIUtils.applyRestOptions(options.getRestOptions(), okBuilder);
@@ -42,7 +41,7 @@ public final class DevCycleLocalApiClient {
 
         adapterBuilder = new Retrofit.Builder()
                 .baseUrl(configUrl)
-                .addConverterFactory(JacksonConverterFactory.create());
+                .addConverterFactory(JacksonConverterFactory.create(OBJECT_MAPPER));
     }
 
     public DevCycleLocalApiClient(String sdkKey, DevCycleLocalOptions options) {

--- a/src/main/java/com/devcycle/sdk/server/local/api/DevCycleLocalClient.java
+++ b/src/main/java/com/devcycle/sdk/server/local/api/DevCycleLocalClient.java
@@ -9,6 +9,7 @@ import com.devcycle.sdk.server.local.bucketing.LocalBucketing;
 import com.devcycle.sdk.server.local.managers.EnvironmentConfigManager;
 import com.devcycle.sdk.server.local.managers.EventQueueManager;
 import com.devcycle.sdk.server.local.model.BucketedUserConfig;
+import com.devcycle.sdk.server.local.model.ConfigMetadata;
 import com.devcycle.sdk.server.local.model.DevCycleLocalOptions;
 import com.devcycle.sdk.server.local.protobuf.SDKVariable_PB;
 import com.devcycle.sdk.server.local.protobuf.VariableForUserParams_PB;
@@ -28,6 +29,7 @@ public final class DevCycleLocalClient implements IDevCycleClient {
     private final EnvironmentConfigManager configManager;
     private EventQueueManager eventQueueManager;
     private final String clientUUID;
+    // raw type here is okay because we're using a generic type for the variable
     private EvalHooksRunner evalHooksRunner;
 
     public DevCycleLocalClient(String sdkKey) {
@@ -156,7 +158,7 @@ public final class DevCycleLocalClient implements IDevCycleClient {
                 .setShouldTrackEvent(true)
                 .build();
 
-        HookContext<T> hookContext = new HookContext<T>(user, key, defaultValue);
+        HookContext<T> hookContext = new HookContext<T>(user, key, defaultValue, getMetadata());
         Variable<T> variable = null;
         ArrayList<EvalHook<T>> hooks = new ArrayList<EvalHook<T>>(evalHooksRunner.getHooks());
         ArrayList<EvalHook<T>> reversedHooks = new ArrayList<EvalHook<T>>(evalHooksRunner.getHooks());
@@ -198,8 +200,12 @@ public final class DevCycleLocalClient implements IDevCycleClient {
                 variable = defaultVariable;
             }
             evalHooksRunner.executeFinally(reversedHooks, hookContext, Optional.of(variable));
-            return variable;
         }
+        return variable;
+    }
+
+    public ConfigMetadata getMetadata() {
+        return configManager.getConfigMetadata();
     }
 
 

--- a/src/main/java/com/devcycle/sdk/server/local/api/DevCycleLocalClient.java
+++ b/src/main/java/com/devcycle/sdk/server/local/api/DevCycleLocalClient.java
@@ -194,7 +194,9 @@ public final class DevCycleLocalClient implements IDevCycleClient {
             if (!(e instanceof BeforeHookError)) {
                 DevCycleLogger.error("Unable to evaluate Variable " + key + " due to error: " + e, e);
             }
-            evalHooksRunner.executeError(reversedHooks, hookContext, e);
+            // For BeforeHookError, pass the original cause to error hooks, not the wrapper
+            Throwable errorToPass = (e instanceof BeforeHookError && e.getCause() != null) ? e.getCause() : e;
+            evalHooksRunner.executeError(reversedHooks, hookContext, errorToPass);
         } finally {
             if (variable == null) {
                 variable = defaultVariable;

--- a/src/main/java/com/devcycle/sdk/server/local/api/DevCycleLocalEventsApiClient.java
+++ b/src/main/java/com/devcycle/sdk/server/local/api/DevCycleLocalEventsApiClient.java
@@ -2,9 +2,9 @@ package com.devcycle.sdk.server.local.api;
 
 import com.devcycle.sdk.server.common.api.APIUtils;
 import com.devcycle.sdk.server.common.api.IDevCycleApi;
+import com.devcycle.sdk.server.common.api.ObjectMapperUtils;
 import com.devcycle.sdk.server.common.interceptor.AuthorizationHeaderInterceptor;
 import com.devcycle.sdk.server.local.model.DevCycleLocalOptions;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
@@ -14,14 +14,13 @@ import java.util.Objects;
 
 public final class DevCycleLocalEventsApiClient {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperUtils.createEventObjectMapper();
     private static final String EVENTS_API_URL = "https://events.devcycle.com/";
     private final OkHttpClient.Builder okBuilder;
     private final Retrofit.Builder adapterBuilder;
     private String eventsApiUrl;
 
     public DevCycleLocalEventsApiClient(String sdkKey, DevCycleLocalOptions options) {
-        OBJECT_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         okBuilder = new OkHttpClient.Builder();
 
         APIUtils.applyRestOptions(options.getRestOptions(), okBuilder);
@@ -35,9 +34,7 @@ public final class DevCycleLocalEventsApiClient {
 
         adapterBuilder = new Retrofit.Builder()
                 .baseUrl(eventsApiUrl)
-                .addConverterFactory(JacksonConverterFactory.create());
-
-
+                .addConverterFactory(JacksonConverterFactory.create(OBJECT_MAPPER));
     }
 
     public IDevCycleApi initialize() {

--- a/src/main/java/com/devcycle/sdk/server/local/managers/EnvironmentConfigManager.java
+++ b/src/main/java/com/devcycle/sdk/server/local/managers/EnvironmentConfigManager.java
@@ -85,9 +85,13 @@ public final class EnvironmentConfigManager {
 
     private ProjectConfig getConfig() throws DevCycleException {        
         // Handle initial request where configMetadata might be null
-        String etag = (this.configMetadata != null) ? this.configMetadata.configETag : null;
-        String lastModified = (this.configMetadata != null) ? this.configMetadata.configLastModified : null;
-        
+        String etag = null;
+        String lastModified = null;
+        if (this.configMetadata != null) {
+            etag = this.configMetadata.getConfigETag();
+            lastModified = this.configMetadata.getConfigLastModified();
+        }
+
         Call<ProjectConfig> config = this.configApiClient.getConfig(this.sdkKey, etag, lastModified);
         ProjectConfig fetchedConfig = getResponseWithRetries(config, 1);
         this.config = fetchedConfig;
@@ -227,7 +231,7 @@ public final class EnvironmentConfigManager {
                 if (this.config != null) {
                     String currentConfigInfo = (this.configMetadata != null) ? 
                         " etag " + this.configMetadata.configETag + " last-modified: " + this.configMetadata.configLastModified :
-                        " (no metadata available)";
+                        "";
                     DevCycleLogger.error("Unable to parse config with etag: " + currentETag + ". Using cache," + currentConfigInfo);
                     return this.config;
                 } else {

--- a/src/main/java/com/devcycle/sdk/server/local/managers/EnvironmentConfigManager.java
+++ b/src/main/java/com/devcycle/sdk/server/local/managers/EnvironmentConfigManager.java
@@ -88,8 +88,8 @@ public final class EnvironmentConfigManager {
         String etag = null;
         String lastModified = null;
         if (this.configMetadata != null) {
-            etag = this.configMetadata.getConfigETag();
-            lastModified = this.configMetadata.getConfigLastModified();
+            etag = this.configMetadata.configETag;
+            lastModified = this.configMetadata.configLastModified;
         }
 
         Call<ProjectConfig> config = this.configApiClient.getConfig(this.sdkKey, etag, lastModified);

--- a/src/main/java/com/devcycle/sdk/server/local/model/ConfigMetadata.java
+++ b/src/main/java/com/devcycle/sdk/server/local/model/ConfigMetadata.java
@@ -2,10 +2,10 @@ package com.devcycle.sdk.server.local.model;
 
 public class ConfigMetadata {
 
-    public String configETag;
-    public String configLastModified;
-    public ProjectMetadata project;
-    public EnvironmentMetadata environment;
+    public final String configETag;
+    public final String configLastModified;
+    public final ProjectMetadata project;
+    public final EnvironmentMetadata environment;
 
     public ConfigMetadata(String currentETag, String headerLastModified, Project project, Environment environment) {
         this.configETag = currentETag;
@@ -14,4 +14,19 @@ public class ConfigMetadata {
         this.environment = new EnvironmentMetadata(environment._id, environment.key);
     }
 
+    public String getConfigETag() {
+        return configETag;
+    }
+
+    public String getConfigLastModified() {
+        return configLastModified;
+    }
+
+    public ProjectMetadata getProject() {
+        return project;
+    }
+
+    public EnvironmentMetadata getEnvironment() {
+        return environment;
+    }
 }

--- a/src/main/java/com/devcycle/sdk/server/local/model/ConfigMetadata.java
+++ b/src/main/java/com/devcycle/sdk/server/local/model/ConfigMetadata.java
@@ -1,0 +1,17 @@
+package com.devcycle.sdk.server.local.model;
+
+public class ConfigMetadata {
+
+    public String configETag;
+    public String configLastModified;
+    public ProjectMetadata project;
+    public EnvironmentMetadata environment;
+
+    public ConfigMetadata(String currentETag, String headerLastModified, Project project, Environment environment) {
+        this.configETag = currentETag;
+        this.configLastModified = headerLastModified;
+        this.project = new ProjectMetadata(project._id, project.key);
+        this.environment = new EnvironmentMetadata(environment._id, environment.key);
+    }
+
+}

--- a/src/main/java/com/devcycle/sdk/server/local/model/ConfigMetadata.java
+++ b/src/main/java/com/devcycle/sdk/server/local/model/ConfigMetadata.java
@@ -13,20 +13,4 @@ public class ConfigMetadata {
         this.project = new ProjectMetadata(project._id, project.key);
         this.environment = new EnvironmentMetadata(environment._id, environment.key);
     }
-
-    public String getConfigETag() {
-        return configETag;
-    }
-
-    public String getConfigLastModified() {
-        return configLastModified;
-    }
-
-    public ProjectMetadata getProject() {
-        return project;
-    }
-
-    public EnvironmentMetadata getEnvironment() {
-        return environment;
-    }
 }

--- a/src/main/java/com/devcycle/sdk/server/local/model/EnvironmentMetadata.java
+++ b/src/main/java/com/devcycle/sdk/server/local/model/EnvironmentMetadata.java
@@ -1,0 +1,11 @@
+package com.devcycle.sdk.server.local.model;
+
+public class EnvironmentMetadata {
+    public String id;
+    public String key;
+
+    public EnvironmentMetadata(String id, String key) {
+        this.id = id;
+        this.key = key;
+    }
+}

--- a/src/main/java/com/devcycle/sdk/server/local/model/EnvironmentMetadata.java
+++ b/src/main/java/com/devcycle/sdk/server/local/model/EnvironmentMetadata.java
@@ -1,11 +1,19 @@
 package com.devcycle.sdk.server.local.model;
 
 public class EnvironmentMetadata {
-    public String id;
-    public String key;
+    public final String id;
+    public final String key;
 
     public EnvironmentMetadata(String id, String key) {
         this.id = id;
         this.key = key;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getKey() {
+        return key;
     }
 }

--- a/src/main/java/com/devcycle/sdk/server/local/model/EnvironmentMetadata.java
+++ b/src/main/java/com/devcycle/sdk/server/local/model/EnvironmentMetadata.java
@@ -8,12 +8,4 @@ public class EnvironmentMetadata {
         this.id = id;
         this.key = key;
     }
-
-    public String getId() {
-        return id;
-    }
-
-    public String getKey() {
-        return key;
-    }
 }

--- a/src/main/java/com/devcycle/sdk/server/local/model/ProjectMetadata.java
+++ b/src/main/java/com/devcycle/sdk/server/local/model/ProjectMetadata.java
@@ -1,0 +1,11 @@
+package com.devcycle.sdk.server.local.model;
+
+public class ProjectMetadata {
+    public String id;
+    public String key;
+
+    public ProjectMetadata(String id, String key) {
+        this.id = id;
+        this.key = key;
+    }
+}

--- a/src/main/java/com/devcycle/sdk/server/local/model/ProjectMetadata.java
+++ b/src/main/java/com/devcycle/sdk/server/local/model/ProjectMetadata.java
@@ -1,11 +1,19 @@
 package com.devcycle.sdk.server.local.model;
 
 public class ProjectMetadata {
-    public String id;
-    public String key;
+    public final String id;
+    public final String key;
 
     public ProjectMetadata(String id, String key) {
         this.id = id;
         this.key = key;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getKey() {
+        return key;
     }
 }

--- a/src/main/java/com/devcycle/sdk/server/local/model/ProjectMetadata.java
+++ b/src/main/java/com/devcycle/sdk/server/local/model/ProjectMetadata.java
@@ -8,12 +8,4 @@ public class ProjectMetadata {
         this.id = id;
         this.key = key;
     }
-
-    public String getId() {
-        return id;
-    }
-
-    public String getKey() {
-        return key;
-    }
 }

--- a/src/test/java/com/devcycle/sdk/server/helpers/LocalConfigServer.java
+++ b/src/test/java/com/devcycle/sdk/server/helpers/LocalConfigServer.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class LocalConfigServer {
     private final HttpServer server;
@@ -26,6 +28,11 @@ public class LocalConfigServer {
     }
 
     public void handleConfigRequest(HttpExchange exchange) throws IOException {
+        // Add required headers for ConfigMetadata creation
+        String currentTime = ZonedDateTime.now().format(DateTimeFormatter.RFC_1123_DATE_TIME);
+        exchange.getResponseHeaders().set("ETag", "\"test-etag-12345\"");
+        exchange.getResponseHeaders().set("Last-Modified", currentTime);
+        
         byte[] responseData = configData.getBytes(StandardCharsets.UTF_8);
         exchange.sendResponseHeaders(200, responseData.length);
         OutputStream outputStream = exchange.getResponseBody();


### PR DESCRIPTION
- add config metadata for project and environment information to be added to the evaluation context
- move the current config etag and last updated inside the config metadata fields 
- add accessor to the local client for getting metadata
- use Objectmapper utils to keep json serialization and unknown property configuration to be centralized. When trying to serialize the project, I was getting issues for unknown properties under `project.settings` for `obfuscation` field and was requiring me to add the unknown fields property to project settings and project so instead centralized the serialization 
- tested using the local example 
