### PR TITLE
fix: update hooks to include feature

### DIFF
--- a/src/main/java/com/devcycle/sdk/server/cloud/api/DevCycleCloudClient.java
+++ b/src/main/java/com/devcycle/sdk/server/cloud/api/DevCycleCloudClient.java
@@ -150,7 +150,7 @@ public final class DevCycleCloudClient implements IDevCycleClient {
             }
 
             variable.setIsDefaulted(false);
-            evalHooksRunner.executeAfter(reversedHooks, context, variable);
+            evalHooksRunner.executeAfter(reversedHooks, context, variable, null);
         } catch (Throwable exception) {
             if (!(exception instanceof BeforeHookError || exception instanceof AfterHookError)) {
                 variable = (Variable<T>) Variable.builder()
@@ -170,7 +170,7 @@ public final class DevCycleCloudClient implements IDevCycleClient {
 
             evalHooksRunner.executeError(reversedHooks, context, exception);
         } finally {
-            evalHooksRunner.executeFinally(reversedHooks, context, Optional.ofNullable(variable));
+            evalHooksRunner.executeFinally(reversedHooks, context, Optional.ofNullable(variable), null);
         }
         return variable;
     }

--- a/src/main/java/com/devcycle/sdk/server/common/model/EvalHook.java
+++ b/src/main/java/com/devcycle/sdk/server/common/model/EvalHook.java
@@ -2,12 +2,14 @@ package com.devcycle.sdk.server.common.model;
 
 import java.util.Optional;
 
+import com.devcycle.sdk.server.local.model.VariableMetadata;
+
 public interface EvalHook<T> {
 
     default Optional<HookContext<T>> before(HookContext<T> ctx) {
         return Optional.empty();
     }
-    default void after(HookContext<T> ctx, Variable<T> variable) {}
+    default void after(HookContext<T> ctx, Variable<T> variable, VariableMetadata variableMetadata) {}
     default void error(HookContext<T> ctx, Throwable e) {}
-    default void onFinally(HookContext<T> ctx, Optional<Variable<T>> variable) {}
+    default void onFinally(HookContext<T> ctx, Optional<Variable<T>> variable, VariableMetadata variableMetadata) {}
 }

--- a/src/main/java/com/devcycle/sdk/server/common/model/EvalHooksRunner.java
+++ b/src/main/java/com/devcycle/sdk/server/common/model/EvalHooksRunner.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import com.devcycle.sdk.server.common.exception.AfterHookError;
 import com.devcycle.sdk.server.common.exception.BeforeHookError;
 import com.devcycle.sdk.server.common.logging.DevCycleLogger;
+import com.devcycle.sdk.server.local.model.VariableMetadata;
 
 /**
  * A class that manages evaluation hooks for the DevCycle SDK.
@@ -81,16 +82,16 @@ public class EvalHooksRunner<T> {
      * @param variable The variable result to pass to the hooks
      * @param <T> The type of the variable value
      */
-    public void executeAfter(ArrayList<EvalHook<T>> hooks, HookContext<T> context, Variable<T> variable) {
+    public void executeAfter(ArrayList<EvalHook<T>> hooks, HookContext<T> context, Variable<T> variable, VariableMetadata variableMetadata) {
         for (EvalHook<T> hook : hooks) {
             try {
-                hook.after(context, variable);
+                hook.after(context, variable, variableMetadata);
             } catch (Exception e) {
                 throw new AfterHookError("After hook failed", e);
             }
         }
     }
-
+    
     /**
      * Runs all error hooks in reverse order.
      *
@@ -115,10 +116,10 @@ public class EvalHooksRunner<T> {
      * @param context The context to pass to the hooks
      * @param variable The variable result to pass to the hooks (may be null)
      */
-    public void executeFinally(ArrayList<EvalHook<T>> hooks, HookContext<T> context, Optional<Variable<T>> variable) {
+    public void executeFinally(ArrayList<EvalHook<T>> hooks, HookContext<T> context, Optional<Variable<T>> variable, VariableMetadata variableMetadata) {
         for (EvalHook<T> hook : hooks) {
             try {
-                hook.onFinally(context, variable);
+                hook.onFinally(context, variable, variableMetadata);
             } catch (Exception e) {
                 // Log finally hook error but don't throw
                 DevCycleLogger.error("Finally hook failed: " + e.getMessage(), e);

--- a/src/main/java/com/devcycle/sdk/server/common/model/EvalHooksRunner.java
+++ b/src/main/java/com/devcycle/sdk/server/common/model/EvalHooksRunner.java
@@ -1,12 +1,12 @@
 package com.devcycle.sdk.server.common.model;
 
-import com.devcycle.sdk.server.common.exception.AfterHookError;
-import com.devcycle.sdk.server.common.exception.BeforeHookError;
-import com.devcycle.sdk.server.common.logging.DevCycleLogger;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
+import com.devcycle.sdk.server.common.exception.AfterHookError;
+import com.devcycle.sdk.server.common.exception.BeforeHookError;
+import com.devcycle.sdk.server.common.logging.DevCycleLogger;
 
 /**
  * A class that manages evaluation hooks for the DevCycle SDK.

--- a/src/main/java/com/devcycle/sdk/server/common/model/PlatformData.java
+++ b/src/main/java/com/devcycle/sdk/server/common/model/PlatformData.java
@@ -1,17 +1,18 @@
 package com.devcycle.sdk.server.common.model;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
 import com.devcycle.sdk.server.common.logging.DevCycleLogger;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
-
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 
 @Data
 @Builder
@@ -34,6 +35,7 @@ public class PlatformData {
     private String sdkVersion = "2.8.1";
 
     @Schema(description = "DevCycle SDK Platform")
+    @Builder.Default
     private String sdkPlatform = null;
 
     @Schema(description = "Hostname where the SDK is running")

--- a/src/main/java/com/devcycle/sdk/server/local/model/VariableMetadata.java
+++ b/src/main/java/com/devcycle/sdk/server/local/model/VariableMetadata.java
@@ -1,0 +1,13 @@
+package com.devcycle.sdk.server.local.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VariableMetadata {
+
+    public final String featureId;
+
+}

--- a/src/test/java/com/devcycle/sdk/server/cloud/DevCycleCloudClientTest.java
+++ b/src/test/java/com/devcycle/sdk/server/cloud/DevCycleCloudClientTest.java
@@ -35,6 +35,7 @@ import com.devcycle.sdk.server.common.model.Meta;
 import com.devcycle.sdk.server.common.model.PlatformData;
 import com.devcycle.sdk.server.common.model.Variable;
 import com.devcycle.sdk.server.helpers.WhiteBox;
+import com.devcycle.sdk.server.local.model.VariableMetadata;
 
 import retrofit2.mock.Calls;
 
@@ -271,13 +272,13 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void after(HookContext<Boolean> ctx, Variable<Boolean> variable) {
+            public void after(HookContext<Boolean> ctx, Variable<Boolean> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
                 Assert.assertTrue(beforeCalled[0]);
             }
 
             @Override
-            public void onFinally(HookContext<Boolean> ctx, Optional<Variable<Boolean>> variable) {
+            public void onFinally(HookContext<Boolean> ctx, Optional<Variable<Boolean>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
                 Assert.assertTrue(afterCalled[0]);
             }
@@ -311,7 +312,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void after(HookContext<Boolean> ctx, Variable<Boolean> variable) {
+            public void after(HookContext<Boolean> ctx, Variable<Boolean> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
             }
 
@@ -321,7 +322,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<Boolean> ctx, Optional<Variable<Boolean>>  variable) {
+            public void onFinally(HookContext<Boolean> ctx, Optional<Variable<Boolean>>  variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
             }
         });
@@ -354,7 +355,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void after(HookContext<Boolean> ctx, Variable<Boolean> variable) {
+            public void after(HookContext<Boolean> ctx, Variable<Boolean> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
             }
 
@@ -364,7 +365,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<Boolean> ctx, Optional<Variable<Boolean>>  variable) {
+            public void onFinally(HookContext<Boolean> ctx, Optional<Variable<Boolean>>  variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
             }
         });
@@ -407,7 +408,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
                 throw new RuntimeException("Test after hook error");
             }
@@ -418,7 +419,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
             }
         });
@@ -461,7 +462,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
             }
 
@@ -471,7 +472,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
                 throw new RuntimeException("Test finally hook error");
             }
@@ -514,7 +515,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
             }
 
@@ -525,7 +526,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
             }
         });
@@ -573,7 +574,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 hook1AfterCalled[0] = true;
             }
 
@@ -583,7 +584,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 hook1FinallyCalled[0] = true;
             }
         });
@@ -597,7 +598,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 hook2AfterCalled[0] = true;
                 throw new RuntimeException("Test hook2 after error");
             }
@@ -608,7 +609,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 hook2FinallyCalled[0] = true;
             }
         });
@@ -659,7 +660,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
             }
 
@@ -670,7 +671,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
             }
         });
@@ -713,7 +714,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
             }
 
@@ -723,7 +724,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
                 throw new RuntimeException("Test finally hook error after previous error");
             }
@@ -767,7 +768,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
             }
 
@@ -778,7 +779,7 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
             }
         });
@@ -822,12 +823,12 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
             }
 
@@ -844,12 +845,12 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[1] = true;
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[1] = true;
             }
 
@@ -908,7 +909,7 @@ public class DevCycleCloudClientTest {
 
         api.addHook(new EvalHook<Boolean>() {
             @Override
-            public void after(HookContext<Boolean> ctx, Variable<Boolean> variable) {
+            public void after(HookContext<Boolean> ctx, Variable<Boolean> variable, VariableMetadata variableMetadata) {
                 // Cloud client should have null metadata since it doesn't manage local config
                 Assert.assertNull("Cloud client metadata should be null", ctx.getMetadata());
                 metadataChecked[0] = true;
@@ -947,12 +948,12 @@ public class DevCycleCloudClientTest {
             }
 
             @Override
-            public void after(HookContext<Boolean> ctx, Variable<Boolean> variable) {
+            public void after(HookContext<Boolean> ctx, Variable<Boolean> variable, VariableMetadata variableMetadata) {
                 metadataWasNull[1] = (ctx.getMetadata() == null);
             }
 
             @Override
-            public void onFinally(HookContext<Boolean> ctx, Optional<Variable<Boolean>> variable) {
+            public void onFinally(HookContext<Boolean> ctx, Optional<Variable<Boolean>> variable, VariableMetadata variableMetadata) {
                 metadataWasNull[2] = (ctx.getMetadata() == null);
             }
         });
@@ -1024,7 +1025,7 @@ public class DevCycleCloudClientTest {
         // First hook
         api.addHook(new EvalHook<Boolean>() {
             @Override
-            public void after(HookContext<Boolean> ctx, Variable<Boolean> variable) {
+            public void after(HookContext<Boolean> ctx, Variable<Boolean> variable, VariableMetadata variableMetadata) {
                 Assert.assertNull("First hook should receive null metadata in cloud client", ctx.getMetadata());
                 metadataChecked[0] = true;
             }
@@ -1033,7 +1034,7 @@ public class DevCycleCloudClientTest {
         // Second hook
         api.addHook(new EvalHook<Boolean>() {
             @Override
-            public void after(HookContext<Boolean> ctx, Variable<Boolean> variable) {
+            public void after(HookContext<Boolean> ctx, Variable<Boolean> variable, VariableMetadata variableMetadata) {
                 Assert.assertNull("Second hook should receive null metadata in cloud client", ctx.getMetadata());
                 metadataChecked[1] = true;
             }

--- a/src/test/java/com/devcycle/sdk/server/local/DevCycleLocalClientTest.java
+++ b/src/test/java/com/devcycle/sdk/server/local/DevCycleLocalClientTest.java
@@ -40,6 +40,7 @@ import com.devcycle.sdk.server.local.model.Environment;
 import com.devcycle.sdk.server.local.model.EnvironmentMetadata;
 import com.devcycle.sdk.server.local.model.Project;
 import com.devcycle.sdk.server.local.model.ProjectMetadata;
+import com.devcycle.sdk.server.local.model.VariableMetadata;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DevCycleLocalClientTest {
@@ -458,13 +459,13 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
                 Assert.assertTrue(beforeCalled[0]);
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
                 Assert.assertTrue(afterCalled[0]);
             }
@@ -495,7 +496,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
             }
 
@@ -505,7 +506,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
             }
         });
@@ -538,7 +539,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
                 throw new RuntimeException("Test after hook error");
             }
@@ -549,7 +550,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
             }
         });
@@ -582,7 +583,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
             }
 
@@ -592,7 +593,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
                 throw new RuntimeException("Test finally hook error");
             }
@@ -625,7 +626,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
             }
 
@@ -636,7 +637,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
             }
         });
@@ -675,7 +676,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 hook1AfterCalled[0] = true;
             }
 
@@ -685,7 +686,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 hook1FinallyCalled[0] = true;
             }
         });
@@ -699,7 +700,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 hook2AfterCalled[0] = true;
                 throw new RuntimeException("Test hook2 after error");
             }
@@ -710,7 +711,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 hook2FinallyCalled[0] = true;
             }
         });
@@ -758,7 +759,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
             }
 
@@ -770,7 +771,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
             }
         });
@@ -803,7 +804,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
             }
 
@@ -815,7 +816,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
             }
         });
@@ -848,7 +849,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {   
                 afterCalled[0] = true;
             }
 
@@ -858,7 +859,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
                 throw new RuntimeException("Test finally hook error after previous error");
             }
@@ -892,7 +893,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
             }
 
@@ -903,7 +904,7 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
             }
         });
@@ -937,12 +938,12 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[0] = true;
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[0] = true;
             }
 
@@ -959,12 +960,12 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 afterCalled[1] = true;
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 finallyCalled[1] = true;
             }
 
@@ -1031,7 +1032,7 @@ public class DevCycleLocalClientTest {
 
         client.addHook(new EvalHook<String>() {
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 // Verify metadata is accessible and properly populated
                 Assert.assertNotNull("Metadata should not be null", ctx.getMetadata());
                 
@@ -1067,12 +1068,12 @@ public class DevCycleLocalClientTest {
             }
 
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 capturedMetadata[1] = ctx.getMetadata();
             }
 
             @Override
-            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+            public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable, VariableMetadata variableMetadata) {
                 capturedMetadata[2] = ctx.getMetadata();
             }
         });
@@ -1132,7 +1133,7 @@ public class DevCycleLocalClientTest {
 
         client.addHook(new EvalHook<String>() {
             @Override
-            public void after(HookContext<String> ctx, Variable<String> variable) {
+            public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                 capturedMetadata[0] = ctx.getMetadata();
             }
         });
@@ -1162,7 +1163,7 @@ public class DevCycleLocalClientTest {
         // First hook
         client.addHook(new EvalHook<String>() {
                          @Override
-             public void after(HookContext<String> ctx, Variable<String> variable) {
+             public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                  Assert.assertNotNull("First hook should receive metadata", ctx.getMetadata());
                  Assert.assertNotNull("First hook metadata should have project", ctx.getMetadata().project);
                  metadataChecked[0] = true;
@@ -1172,7 +1173,7 @@ public class DevCycleLocalClientTest {
          // Second hook
          client.addHook(new EvalHook<String>() {
              @Override
-             public void after(HookContext<String> ctx, Variable<String> variable) {
+             public void after(HookContext<String> ctx, Variable<String> variable, VariableMetadata variableMetadata) {
                  Assert.assertNotNull("Second hook should receive metadata", ctx.getMetadata());
                  Assert.assertNotNull("Second hook metadata should have environment", ctx.getMetadata().environment);
                  metadataChecked[1] = true;


### PR DESCRIPTION
- chore: add Builder.Default to address build warning
- fix: update local bucketing hooks to work with `SDKVariable_PB` and add cloud hooks that work with `Variable<T>`