### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ protobuf {
 
 ext {
     retrofit_version = "2.11.0"
-    jackson_version = "2.18.6"
+    jackson_version = "2.18.9"
     swagger_annotations_version = "2.2.18"
     lombok_version = "1.18.30"
     okhttp_version = "4.12.0"


### PR DESCRIPTION
## Summary

- Resolved 4 open Dependabot security alerts by bumping jackson-databind from 2.18.6 to 2.18.9

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #15 | `com.fasterxml.jackson.core:jackson-databind` | **medium** | Bumped to 2.18.9 via `jackson_version` in build.gradle |
| #14 | `com.fasterxml.jackson.core:jackson-databind` | **medium** | Bumped to 2.18.9 via `jackson_version` in build.gradle |
| #13 | `com.fasterxml.jackson.core:jackson-databind` | **high** | Bumped to 2.18.9 via `jackson_version` in build.gradle |
| #12 | `com.fasterxml.jackson.core:jackson-databind` | **high** | Bumped to 2.18.9 via `jackson_version` in build.gradle |