### PR TITLE
feat(openfeature): support long variable evaluation

### DIFF
--- a/src/main/java/com/devcycle/sdk/server/openfeature/DevCycleProvider.java
+++ b/src/main/java/com/devcycle/sdk/server/openfeature/DevCycleProvider.java
@@ -79,6 +79,29 @@ public class DevCycleProvider implements FeatureProvider {
     }
 
     @Override
+    public ProviderEvaluation<Long> getLongEvaluation(String key, Long defaultValue, EvaluationContext ctx) {
+        // DevCycle has no native long type: internally all numbers are stored as Doubles, which only
+        // represent integers exactly up to 2^53. Resolve the value through the Double-backed NUMBER type
+        // and narrow it to a Long. Values beyond 2^53 cannot be represented without precision loss.
+        ProviderEvaluation<Double> eval = resolvePrimitiveVariable(key, defaultValue.doubleValue(), ctx);
+
+        Double value = eval.getValue();
+        boolean defaulted = Reason.DEFAULT.toString().equals(eval.getReason())
+                || Reason.ERROR.toString().equals(eval.getReason());
+        // Preserve the exact default on default/error so a large default value is not lossily round-tripped.
+        Long longValue = (defaulted || value == null) ? defaultValue : Long.valueOf(value.longValue());
+
+        return ProviderEvaluation.<Long>builder()
+                .value(longValue)
+                .variant(eval.getVariant())
+                .reason(eval.getReason())
+                .errorCode(eval.getErrorCode())
+                .errorMessage(eval.getErrorMessage())
+                .flagMetadata(eval.getFlagMetadata())
+                .build();
+    }
+
+    @Override
     public ProviderEvaluation<Double> getDoubleEvaluation(String key, Double defaultValue, EvaluationContext ctx) {
         return resolvePrimitiveVariable(key, defaultValue, ctx);
     }

--- a/src/main/java/com/devcycle/sdk/server/openfeature/DevCycleProvider.java
+++ b/src/main/java/com/devcycle/sdk/server/openfeature/DevCycleProvider.java
@@ -79,29 +79,6 @@ public class DevCycleProvider implements FeatureProvider {
     }
 
     @Override
-    public ProviderEvaluation<Long> getLongEvaluation(String key, Long defaultValue, EvaluationContext ctx) {
-        // DevCycle has no native long type: internally all numbers are stored as Doubles, which only
-        // represent integers exactly up to 2^53. Resolve the value through the Double-backed NUMBER type
-        // and narrow it to a Long. Values beyond 2^53 cannot be represented without precision loss.
-        ProviderEvaluation<Double> eval = resolvePrimitiveVariable(key, defaultValue.doubleValue(), ctx);
-
-        Double value = eval.getValue();
-        boolean defaulted = Reason.DEFAULT.toString().equals(eval.getReason())
-                || Reason.ERROR.toString().equals(eval.getReason());
-        // Preserve the exact default on default/error so a large default value is not lossily round-tripped.
-        Long longValue = (defaulted || value == null) ? defaultValue : Long.valueOf(value.longValue());
-
-        return ProviderEvaluation.<Long>builder()
-                .value(longValue)
-                .variant(eval.getVariant())
-                .reason(eval.getReason())
-                .errorCode(eval.getErrorCode())
-                .errorMessage(eval.getErrorMessage())
-                .flagMetadata(eval.getFlagMetadata())
-                .build();
-    }
-
-    @Override
     public ProviderEvaluation<Double> getDoubleEvaluation(String key, Double defaultValue, EvaluationContext ctx) {
         return resolvePrimitiveVariable(key, defaultValue, ctx);
     }

--- a/src/test/java/com/devcycle/sdk/server/openfeature/DevCycleProviderTest.java
+++ b/src/test/java/com/devcycle/sdk/server/openfeature/DevCycleProviderTest.java
@@ -181,7 +181,7 @@ public class DevCycleProviderTest {
         IDevCycleClient dvcClient = mock(IDevCycleClient.class);
         when(dvcClient.isInitialized()).thenReturn(true);
 
-        // 5_000_000_000 exceeds Integer.MAX_VALUE but is well within the double safe-integer range (2^53).
+        // 5_000_000_000 exceeds Integer.MAX_VALUE but is well within the double safe-integer range (2^53 - 1).
         Double variableValue = 5_000_000_000.0;
         Long defaultValue = 0L;
 
@@ -219,7 +219,7 @@ public class DevCycleProviderTest {
         IDevCycleClient dvcClient = mock(IDevCycleClient.class);
         when(dvcClient.isInitialized()).thenReturn(true);
 
-        // 2^53 exceeds the double safe-integer range, so it cannot be narrowed to a long without precision loss.
+        // 2^53 exceeds the double max safe integer (2^53 - 1), so it cannot be narrowed to a long without precision loss.
         Double variableValue = 9_007_199_254_740_992.0;
         Long defaultValue = 0L;
 

--- a/src/test/java/com/devcycle/sdk/server/openfeature/DevCycleProviderTest.java
+++ b/src/test/java/com/devcycle/sdk/server/openfeature/DevCycleProviderTest.java
@@ -171,13 +171,18 @@ public class DevCycleProviderTest {
         Assert.assertNull(result.getErrorCode());
     }
 
+    // DevCycle has no native long type; numbers are stored as Doubles. The OpenFeature SDK's default
+    // getLongEvaluation delegates to getDoubleEvaluation (DevCycle's native number path) and safely
+    // narrows the result to a long. These tests lock in that behavior; DevCycleProvider does not
+    // override getLongEvaluation because the default already handles it correctly.
+
     @Test
-    public void testResolveLongVariable() {
+    public void testResolveLongVariableBeyondIntRange() {
         IDevCycleClient dvcClient = mock(IDevCycleClient.class);
         when(dvcClient.isInitialized()).thenReturn(true);
 
-        // DevCycle stores numbers as Doubles internally, so the resolved value comes back as a Double.
-        Double variableValue = 1234.0;
+        // 5_000_000_000 exceeds Integer.MAX_VALUE but is well within the double safe-integer range (2^53).
+        Double variableValue = 5_000_000_000.0;
         Long defaultValue = 0L;
 
         when(dvcClient.variable(any(), any(), any())).thenReturn(Variable.builder().key("some-flag").value(variableValue).defaultValue(0.0).type(Variable.TypeEnum.NUMBER).build());
@@ -186,9 +191,45 @@ public class DevCycleProviderTest {
 
         ProviderEvaluation<Long> result = provider.getLongEvaluation("some-flag", defaultValue, new ImmutableContext("user-1234"));
         Assert.assertNotNull(result);
-        Assert.assertEquals(result.getValue(), Long.valueOf(1234L));
+        Assert.assertEquals(result.getValue(), Long.valueOf(5_000_000_000L));
         Assert.assertEquals(result.getReason(), Reason.TARGETING_MATCH.toString());
         Assert.assertNull(result.getErrorCode());
+    }
+
+    @Test
+    public void testResolveLongVariableFractionalIsTypeMismatch() {
+        IDevCycleClient dvcClient = mock(IDevCycleClient.class);
+        when(dvcClient.isInitialized()).thenReturn(true);
+
+        // A non-integer number cannot be represented as a long; the default should surface a type mismatch.
+        Double variableValue = 10.5;
+        Long defaultValue = 0L;
+
+        when(dvcClient.variable(any(), any(), any())).thenReturn(Variable.builder().key("some-flag").value(variableValue).defaultValue(0.0).type(Variable.TypeEnum.NUMBER).build());
+
+        DevCycleProvider provider = new DevCycleProvider(dvcClient);
+
+        ProviderEvaluation<Long> result = provider.getLongEvaluation("some-flag", defaultValue, new ImmutableContext("user-1234"));
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getErrorCode(), ErrorCode.TYPE_MISMATCH);
+    }
+
+    @Test
+    public void testResolveLongVariableBeyondSafeRangeIsTypeMismatch() {
+        IDevCycleClient dvcClient = mock(IDevCycleClient.class);
+        when(dvcClient.isInitialized()).thenReturn(true);
+
+        // 2^53 exceeds the double safe-integer range, so it cannot be narrowed to a long without precision loss.
+        Double variableValue = 9_007_199_254_740_992.0;
+        Long defaultValue = 0L;
+
+        when(dvcClient.variable(any(), any(), any())).thenReturn(Variable.builder().key("some-flag").value(variableValue).defaultValue(0.0).type(Variable.TypeEnum.NUMBER).build());
+
+        DevCycleProvider provider = new DevCycleProvider(dvcClient);
+
+        ProviderEvaluation<Long> result = provider.getLongEvaluation("some-flag", defaultValue, new ImmutableContext("user-1234"));
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getErrorCode(), ErrorCode.TYPE_MISMATCH);
     }
 
     @Test

--- a/src/test/java/com/devcycle/sdk/server/openfeature/DevCycleProviderTest.java
+++ b/src/test/java/com/devcycle/sdk/server/openfeature/DevCycleProviderTest.java
@@ -172,6 +172,26 @@ public class DevCycleProviderTest {
     }
 
     @Test
+    public void testResolveLongVariable() {
+        IDevCycleClient dvcClient = mock(IDevCycleClient.class);
+        when(dvcClient.isInitialized()).thenReturn(true);
+
+        // DevCycle stores numbers as Doubles internally, so the resolved value comes back as a Double.
+        Double variableValue = 1234.0;
+        Long defaultValue = 0L;
+
+        when(dvcClient.variable(any(), any(), any())).thenReturn(Variable.builder().key("some-flag").value(variableValue).defaultValue(0.0).type(Variable.TypeEnum.NUMBER).build());
+
+        DevCycleProvider provider = new DevCycleProvider(dvcClient);
+
+        ProviderEvaluation<Long> result = provider.getLongEvaluation("some-flag", defaultValue, new ImmutableContext("user-1234"));
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getValue(), Long.valueOf(1234L));
+        Assert.assertEquals(result.getReason(), Reason.TARGETING_MATCH.toString());
+        Assert.assertNull(result.getErrorCode());
+    }
+
+    @Test
     public void testResolveDoubleVariable() {
         IDevCycleClient dvcClient = mock(IDevCycleClient.class);
         when(dvcClient.isInitialized()).thenReturn(true);


### PR DESCRIPTION
## Summary

- Add `Long` evaluation support by upgrading the OpenFeature SDK to `1.22.0`.

## Why no custom override

DevCycle stores numbers as `Double`, so the SDK default safely converts them to `long` and returns `TYPE_MISMATCH` for fractional or out-of-range values. A custom override would add no capability and could remove these safeguards.