### PR TITLE
chore(deps): bump dev.openfeature:sdk to 1.22.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ ext {
     junit_version = "4.13.2"
     mockito_core_version = "5.6.0"
     protobuf_version = "3.25.7"
-    openfeature_version = "1.14.2"
+    openfeature_version = "1.22.0"
     eventsource_version = "4.1.1"
 }
 


### PR DESCRIPTION
## Summary
- Bumps `dev.openfeature:sdk` from 1.14.2 to 1.22.0 (one line in `build.gradle`)
- No provider code changes required; 117 tests pass, 0 failures

### Notes
Validated the three risky changes against the 1.22.0 bytecode rather than the changelog:

- **1.22.0 domain binding:** `initialize(ctx, domain)` and `isDomainScoped()` are default methods, and the 2-arg default delegates to the 1-arg one. `DevCycleProvider` keeps receiving the same call, so the readiness poll is unaffected.
- **1.21.0 shutdown (spec 1.6.2):** the change is in `OpenFeatureAPI.shutdown()`, not the provider contract. Worth knowing as a consumer-facing behavior change: anyone calling `OpenFeatureAPI.shutdown()` and then re-registering a provider must re-add global hooks and re-set the global evaluation context. Nothing in this repo does that.
- **1.20.x:** `getLongEvaluation` is a default that routes through `getDoubleEvaluation` with range validation, which suits our all-doubles internal representation. Empty-string targeting keys were already guarded in `DevCycleUser.java:147`.

Follow-up worth its own PR: the provider implements plain `FeatureProvider` and never emits `PROVIDER_READY` / `PROVIDER_ERROR`, which is why `initialize()` still needs the 2s busy-wait poll.
