### PR TITLE
fix(sse): correct SSE-connected config polling interval from 15 hours to 15 minutes

### DIFF
--- a/src/main/java/com/devcycle/sdk/server/local/managers/EnvironmentConfigManager.java
+++ b/src/main/java/com/devcycle/sdk/server/local/managers/EnvironmentConfigManager.java
@@ -45,7 +45,7 @@ public final class EnvironmentConfigManager {
     private final String sdkKey;
     private final int pollingIntervalMS;
     // Once SSE is connected, polling only acts as a backstop for missed messages
-    private static final int SSE_POLL_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
+    private static final int SSE_POLL_INTERVAL_MS = (int) TimeUnit.MINUTES.toMillis(15); // 15 minutes
     private boolean pollingEnabled = true;
 
     public EnvironmentConfigManager(String sdkKey, LocalBucketing localBucketing, DevCycleLocalOptions options) {

--- a/src/main/java/com/devcycle/sdk/server/local/managers/EnvironmentConfigManager.java
+++ b/src/main/java/com/devcycle/sdk/server/local/managers/EnvironmentConfigManager.java
@@ -44,7 +44,8 @@ public final class EnvironmentConfigManager {
 
     private final String sdkKey;
     private final int pollingIntervalMS;
-    private static final int pollingIntervalSSEMS = 15 * 60 * 60 * 1000;
+    // Once SSE is connected, polling only acts as a backstop for missed messages
+    private static final int SSE_POLL_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
     private boolean pollingEnabled = true;
 
     public EnvironmentConfigManager(String sdkKey, LocalBucketing localBucketing, DevCycleLocalOptions options) {
@@ -131,10 +132,10 @@ public final class EnvironmentConfigManager {
 
     private Void handleSSEStarted(StartedEvent startedEvent) {
         isSSEConnected = true;
-        DevCycleLogger.debug("SSE Connected - setting polling interval to " + pollingIntervalSSEMS);
+        DevCycleLogger.debug("SSE Connected - setting polling interval to " + SSE_POLL_INTERVAL_MS);
         scheduler.shutdown();
         scheduler = setupScheduler();
-        scheduler.scheduleAtFixedRate(getConfigRunnable, 0, pollingIntervalSSEMS, TimeUnit.MILLISECONDS);
+        scheduler.scheduleAtFixedRate(getConfigRunnable, 0, SSE_POLL_INTERVAL_MS, TimeUnit.MILLISECONDS);
         return null;
     }
 


### PR DESCRIPTION
`pollingIntervalSSEMS` was `15 * 60 * 60 * 1000`, which is 15 hours, not 15 minutes. Once SSE connects, `handleSSEStarted` swaps the normal polling interval for this one, so the backstop poll that catches missed SSE messages was effectively never running. js-sdks uses 10 minutes for the same backstop, go-server-sdk uses 5.

Also renames it to `SSE_POLL_INTERVAL_MS` to match the other interval constants and make the units explicit.

### Notes
`handleSSEError` still only logs: it doesn't reset `isSSEConnected` or restore the normal polling interval. Both js-sdks and go-server-sdk do restore polling on SSE failure, happy to do that as a follow-up since it's a behaviour change rather than a units fix.
